### PR TITLE
Now it's possible switch format from Json to Yaml and viceversa

### DIFF
--- a/playground/next/editor.mjs
+++ b/playground/next/editor.mjs
@@ -1,41 +1,41 @@
 /* globals: jsonld */
 
-import { EditorView, basicSetup } from "codemirror";
-import { createApp } from "petite-vue";
-import { Compartment, EditorState, RangeSetBuilder } from "@codemirror/state";
-import { indentWithTab } from "@codemirror/commands";
-import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
-import { syntaxTree, StreamLanguage } from "@codemirror/language";
-import { ntriples } from "@codemirror/legacy-modes/mode/ntriples";
-import { Decoration, keymap, ViewPlugin } from "@codemirror/view";
-import { linter } from "@codemirror/lint";
-import YAML from "yaml";
-import { yaml } from "@codemirror/lang-yaml";
-import * as cborld from "@digitalbazaar/cborld";
-import * as cbor2 from "cbor2";
-import jsonld from "jsonld";
+import {EditorView, basicSetup} from 'codemirror';
+import {createApp} from "petite-vue";
+import {Compartment, EditorState, RangeSetBuilder} from '@codemirror/state'
+import {indentWithTab} from '@codemirror/commands';
+import {json, jsonLanguage, jsonParseLinter} from "@codemirror/lang-json";
+import {syntaxTree, StreamLanguage} from '@codemirror/language';
+import {ntriples} from '@codemirror/legacy-modes/mode/ntriples';
+import {Decoration, keymap, ViewPlugin} from '@codemirror/view';
+import {linter} from '@codemirror/lint';
+import YAML from 'yaml';
+import {yaml} from '@codemirror/lang-yaml';
+import * as cborld from '@digitalbazaar/cborld';
+import * as cbor2 from 'cbor2';
+import jsonld from 'jsonld';
 
 // Setup JSON-LD documentLoader
 const xhrDocumentLoader = jsonld.documentLoaders.xhr();
 // FIXME: add UI to let users control and set context mapping
-jsonld.documentLoader = function (url) {
+jsonld.documentLoader = function(url) {
   // rewrite URLs that we know have secure JSON-LD Contexts
-  if (url === "http://schema.org/" || url === "http://schema.org") {
-    url = "https://schema.org/";
+  if(url === 'http://schema.org/' || url === 'http://schema.org') {
+    url = 'https://schema.org/';
   }
 
   // if a non-HTTPS URL, use the proxy since we run in HTTPS only mode
-  if (!url.startsWith("https://")) {
+  if(!url.startsWith('https://')) {
     url = [
       location.protocol,
-      "//",
+      '//',
       location.host,
       // NOTE: using hard-coded path so file can be shared with dev page
       //location.pathname,
-      "/playground/",
-      "proxy?url=",
-      url,
-    ].join("");
+      '/playground/',
+      'proxy?url=',
+      url
+    ].join('');
   }
 
   return xhrDocumentLoader(url);
@@ -44,107 +44,40 @@ jsonld.documentLoader = function (url) {
 const jsonLdAtTerms = {
   // JSON-LD terms usable as keys
   keys: [
-    {
-      label: "@context",
-      type: "keyword",
-      info: "Defines the JSON-LD context",
-      boost: 90,
-    },
-    {
-      label: "@id",
-      type: "keyword",
-      info: "Specifies the unique identifier of an entity",
-      boost: 80,
-    },
-    {
-      label: "@type",
-      type: "keyword",
-      info: "Defines the type of an entity",
-      boost: 70,
-    },
-    {
-      label: "@value",
-      type: "keyword",
-      info: "Represents the value of a node",
-    },
-    {
-      label: "@language",
-      type: "keyword",
-      info: "Specifies the language of a string value",
-    },
+    { label: "@context", type: "keyword", info: "Defines the JSON-LD context", boost: 90 },
+    { label: "@id", type: "keyword", info: "Specifies the unique identifier of an entity", boost: 80 },
+    { label: "@type", type: "keyword", info: "Defines the type of an entity", boost: 70 },
+    { label: "@value", type: "keyword", info: "Represents the value of a node" },
+    { label: "@language", type: "keyword", info: "Specifies the language of a string value" },
     { label: "@graph", type: "keyword", info: "Represents a named graph" },
     { label: "@list", type: "keyword", info: "Denotes an ordered list" },
     { label: "@set", type: "keyword", info: "Denotes an unordered set" },
     { label: "@reverse", type: "keyword", info: "Defines reverse properties" },
-    {
-      label: "@index",
-      type: "keyword",
-      info: "Specifies an index for ordered data",
-    },
+    { label: "@index", type: "keyword", info: "Specifies an index for ordered data" },
     { label: "@base", type: "keyword", info: "Defines the base IRI" },
-    {
-      label: "@vocab",
-      type: "keyword",
-      info: "Defines the default vocabulary",
-    },
-    {
-      label: "@container",
-      type: "keyword",
-      info: "Specifies container types for properties",
-    },
+    { label: "@vocab", type: "keyword", info: "Defines the default vocabulary" },
+    { label: "@container", type: "keyword", info: "Specifies container types for properties" },
     { label: "@nest", type: "keyword", info: "Allows nesting of properties" },
     { label: "@prefix", type: "keyword", info: "Defines a prefix mapping" },
-    {
-      label: "@propagate",
-      type: "keyword",
-      info: "Controls context propagation",
-    },
+    { label: "@propagate", type: "keyword", info: "Controls context propagation" },
     { label: "@protected", type: "keyword", info: "Prevents term overrides" },
-    {
-      label: "@version",
-      type: "keyword",
-      info: "Specifies the JSON-LD version",
-    },
-    {
-      label: "@none",
-      type: "keyword",
-      info: "Denote as not part of the index",
-    },
+    { label: "@version", type: "keyword", info: "Specifies the JSON-LD version" },
+    { label: "@none", type: "keyword", info: "Denote as not part of the index" }
   ],
   // JSON-LD terms usable as values
   values: [
-    {
-      label: "@id",
-      type: "keyword",
-      info: "The value of this term is an IRI.",
-      parent: "@type",
-    },
-    {
-      label: "@json",
-      type: "keyword",
-      info: "Specifies the type as a JSON literal (`rdf:JSON`).",
-      parent: "@type",
-    },
-    {
-      label: "@list",
-      type: "keyword",
-      info: "Denotes an ordered list",
-      parent: "@container",
-    },
-    {
-      label: "@set",
-      type: "keyword",
-      info: "Denotes an unordered set",
-      parent: "@container",
-    },
-    { label: "@none", type: "keyword", info: "", parent: "@type" },
-  ],
+    { label: "@id", type: "keyword", info: "The value of this term is an IRI.", parent: "@type" },
+    { label: "@json", type: "keyword", info: "Specifies the type as a JSON literal (`rdf:JSON`).", parent: "@type" },
+    { label: "@list", type: "keyword", info: "Denotes an ordered list", parent: "@container" },
+    { label: "@set", type: "keyword", info: "Denotes an unordered set", parent: "@container" },
+    { label: "@none", type: "keyword", info: "", parent: "@type" }
+  ]
 };
 
-// editorListener ora riesce a gestire sia JSON che YAML a seconda dell'impostazione di `options.formatMode`
+// TODO: the next two functions could probably become a petite-vue component
 function editorListener(docName) {
-  let changes = [];
-  let timer;
+  let changes = []; // keep the changes as a list; then pick the last one
+  let timer; // we only want one timer, once the last one is done, use the result
   function debounce(fn, delay) {
     return (...args) => {
       clearTimeout(timer);
@@ -156,26 +89,26 @@ function editorListener(docName) {
     if (update.docChanged) {
       changes.push(update.state.doc.toString());
       debounce((docName) => {
-        const latestChange = changes[changes.length - 1];
-        if (latestChange === "") {
-          this[docName] = "";
-          this.rawDoc = "";
+        // set the global `doc` to the latest string from the editor
+        const latestChange = changes[changes.length-1];
+        if (latestChange === '') {
+          this[docName] = '';
           this.parseError = {};
-          setEditorValue(readOnlyEditor, "");
+          setEditorValue(readOnlyEditor, '');
           return;
         } else {
-          this.rawDoc = latestChange;
           try {
             const parsed =
               this.options.formatMode === "yaml"
                 ? YAML.parse(latestChange)
                 : JSON.parse(latestChange);
+                
             this[docName] = parsed;
             this.parseError = {};
             this.setOutputTab(this.outputTab);
           } catch (err) {
             this.parseError = err;
-          }
+          };
         }
       }, 1000).call(this, docName);
     }
@@ -218,32 +151,28 @@ function completeJSONLDTerms(context) {
 
   const textBefore = context.state.sliceDoc(nodeBefore.from, context.pos);
   const tagBefore = /@\w*$/.exec(textBefore);
-  if (
-    (!tagBefore && !context.explicit) ||
-    (nodeBefore.name === "}" && nodeBefore._parent?.name === "Object") ||
-    nodeBefore.name === "JsonText"
-  ) {
+  if (!tagBefore && !context.explicit
+      || (nodeBefore.name === '}' && nodeBefore._parent?.name === 'Object')
+      || (nodeBefore.name === 'JsonText')) {
     return null;
   }
 
   // set the default list of term options
   let options = jsonLdAtTerms.keys.map(termsInQuotes);
-  if (nodeBefore._parent?.name === "Property") {
+  if (nodeBefore._parent?.name === 'Property') {
     switch (nodeBefore.name) {
-      case "String":
-      case ":":
+      case 'String':
+      case ':':
         const termParents = jsonLdAtTerms.values.map((term) => term.parent);
         if (termParents.indexOf(nearestProperty) > -1) {
           // limit the term list when we know we can
-          options = jsonLdAtTerms.values.filter(
-            (term) => term?.parent === nearestProperty,
-          );
+          options = jsonLdAtTerms.values.filter((term) => term?.parent === nearestProperty);
         } else {
           options = jsonLdAtTerms.values;
         }
-        if (nodeBefore.name === ":") options.map(termsInQuotes);
+        if (nodeBefore.name === ':') options.map(termsInQuotes);
         break;
-      case "PropertyName":
+      case 'PropertyName':
         // TODO: not sure why `apply` from termsInQuotes hangs around sometimes
         // ...but it does...so this removes the `apply` value if present
         options = jsonLdAtTerms.keys.map((term) => {
@@ -251,92 +180,86 @@ function completeJSONLDTerms(context) {
           return term;
         });
         break;
-      case "Object":
+      case 'Object':
         // we're not inside of quotation marks...so add them also
         options = jsonLdAtTerms.keys.map(termsInQuotes);
         break;
     }
-  } else if (nodeBefore._parent?.name === "Object") {
-    if (nodeBefore.name === "{" || nodeBefore.name === "Property") {
+  } else if (nodeBefore._parent?.name === 'Object') {
+    if (nodeBefore.name === '{' || nodeBefore.name === 'Property') {
       options = jsonLdAtTerms.keys.map(termsInQuotes);
     }
   }
 
   return {
     from: tagBefore ? nodeBefore.from + tagBefore.index : context.pos,
-    options,
+    options
   };
 }
 
 const jsonLdCompletions = jsonLanguage.data.of({
-  autocomplete: completeJSONLDTerms,
+  autocomplete: completeJSONLDTerms
 });
 
 // Create a decoration that applies a CSS class for JSON‑LD property names
-const jsonLdPropertyDecoration = Decoration.mark({
-  class: "cm-jsonld-property",
-});
+const jsonLdPropertyDecoration = Decoration.mark({ class: 'cm-jsonld-property' });
 
 const jsonLdKeywords = new Set(
-  [].concat(...Object.values(jsonLdAtTerms)).map((term) => term.label),
-);
+  [].concat(...Object.values(jsonLdAtTerms)).map((term) => term.label));
 
 /**
  * A view plugin that scans the document for PropertyName nodes and, if their
  * content (without quotes) is a JSON‑LD keyword, adds a decoration to style it.
  */
-const jsonLdKeywordHighlighter = ViewPlugin.fromClass(
-  class {
-    constructor(view) {
-      this.decorations = this.buildDecorations(view);
-    }
+const jsonLdKeywordHighlighter = ViewPlugin.fromClass(class {
+  constructor(view) {
+    this.decorations = this.buildDecorations(view);
+  }
 
-    update(update) {
-      if (update.docChanged || update.viewportChanged) {
-        this.decorations = this.buildDecorations(update.view);
-      }
+  update(update) {
+    if (update.docChanged || update.viewportChanged) {
+      this.decorations = this.buildDecorations(update.view);
     }
+  }
 
-    buildDecorations(view) {
-      let builder = new RangeSetBuilder();
-      let tree = syntaxTree(view.state);
-      // Only inspect nodes in the current viewport
-      tree.iterate({
-        from: view.viewport.from,
-        to: view.viewport.to,
-        enter: (node) => {
-          // Look for property names (as defined by lang-json)
-          if (node.name === "PropertyName" || node.name === "String") {
-            let token = view.state.doc.sliceString(node.from, node.to);
-            // Remove the surrounding quotes, if any
-            if (token.startsWith('"') && token.endsWith('"')) {
-              token = token.slice(1, -1);
-            }
-            if (jsonLdKeywords.has(token)) {
-              builder.add(node.from, node.to, jsonLdPropertyDecoration);
-            }
+  buildDecorations(view) {
+    let builder = new RangeSetBuilder();
+    let tree = syntaxTree(view.state);
+    // Only inspect nodes in the current viewport
+    tree.iterate({
+      from: view.viewport.from,
+      to: view.viewport.to,
+      enter: (node) => {
+        // Look for property names (as defined by lang-json)
+        if (node.name === "PropertyName" || node.name === "String") {
+          let token = view.state.doc.sliceString(node.from, node.to);
+          // Remove the surrounding quotes, if any
+          if (token.startsWith('"') && token.endsWith('"')) {
+            token = token.slice(1, -1);
           }
-        },
-      });
-      return builder.finish();
-    }
+          if (jsonLdKeywords.has(token)) {
+            builder.add(node.from, node.to, jsonLdPropertyDecoration);
+          }
+        }
+      }
+    });
+    return builder.finish();
+  }
 
-    destroy() {}
-  },
-  {
-    decorations: (v) => v.decorations,
-  },
-);
+  destroy() {}
+}, {
+  decorations: v => v.decorations
+});
 
 // A base theme for our decoration
 const jsonLdHighlightTheme = EditorView.baseTheme({
-  ".cm-jsonld-property": {
-    color: "#333",
-    fontWeight: "bold",
-  },
+  '.cm-jsonld-property': {
+    color: '#333',
+    fontWeight: 'bold'
+  }
 });
 
-// initEditor ora riesce a gestire sia JSON che YAML a seconda dell'impostazione di `options.formatMode`
+// initEditor can now handle both JSON and YAML depending on the `options.formatMode` setting
 function initEditor(id, content, varName) {
   const lang = this.options.formatMode;
   const languageExtension = lang === "yaml" ? yaml() : json();
@@ -361,18 +284,18 @@ function initEditor(id, content, varName) {
 const language = new Compartment();
 
 const readOnlyEditor = new EditorView({
-  parent: document.getElementById("read-only-editor"),
-  doc: "",
+  parent: document.getElementById('read-only-editor'),
+  doc: '',
   extensions: [
     basicSetup,
     language.of(json()),
     EditorState.readOnly.of(true),
     EditorView.editable.of(false),
-    EditorView.contentAttributes.of({ tabindex: "0" }),
-  ],
+    EditorView.contentAttributes.of({tabindex: '0'})
+  ]
 });
 
-// setEditorValue ora riesce a gestire sia JSON che YAML a seconda dell'impostazione di `options.formatMode`
+// initEditor can now handle both JSON and YAML depending on the `options.formatMode` setting
 function setEditorValue(_editor, doc, lang) {
   if (_editor) {
     let languageExtension;
@@ -401,96 +324,93 @@ function setEditorValue(_editor, doc, lang) {
 }
 
 window.app = createApp({
-  doc: "",
+  doc: '',
   contextDoc: {},
   frameDoc: {},
   tableQuads: {},
-  yamlLD: "",
+  yamlLD: '',
   cborLD: {
     bytes: {},
-    hex: "",
+    hex: '',
     jsonldSize: 0,
     size: 0,
-    percentage: 0,
+    percentage: 0
   },
-  remoteDocURL: "",
-  remoteSideDocURL: "",
-  message: { type: "", text: "" },
+  remoteDocURL: '',
+  remoteSideDocURL: '',
+  message: {type: '', text: ''},
   parseError: {},
-  inputTab: "json-ld",
-  outputTab: "expanded",
+  inputTab: 'json-ld',
+  outputTab: 'expanded',
   options: {
     processingMode: "json-ld-1.1",
     formatMode: "yaml",
     base: "",
     compactArrays: true,
     compactToRelative: true,
-    rdfDirection: "",
-    safe: false,
+    rdfDirection: '',
+    safe: false
   },
   tabs: {
-    expanded: { icon: "expand alternate", label: "Expanded" },
-    compacted: { icon: "compress alternate", label: "Compacted" },
-    flattened: { icon: "bars", label: "Flattened" },
-    framed: { icon: "crop alternate", label: "Framed" },
-    nquads: { icon: "rdf-icon-rdf", label: "N-Quads" },
-    canonized: { icon: "archive", label: "Canonized" },
-    table: { icon: "th", label: "Table" },
-    yamlld: { icon: "stream", label: "YAML-LD" },
-    cborld: { icon: "robot", label: "CBOR-LD" },
+    expanded: {icon: 'expand alternate', label: 'Expanded'},
+    compacted: {icon: 'compress alternate', label: 'Compacted'},
+    flattened: {icon: 'bars', label: 'Flattened'},
+    framed: {icon: 'crop alternate', label: 'Framed'},
+    nquads: {icon: 'rdf-icon-rdf', label: 'N-Quads'},
+    canonized: {icon: 'archive', label: 'Canonized'},
+    table: {icon: 'th', label: 'Table'},
+    yamlld: {icon: 'stream', label: 'YAML-LD'},
+    cborld: {icon: 'robot', label: 'CBOR-LD'}
   },
   // computed
   get editorColumns() {
-    if (["compacted", "flattened", "framed"].indexOf(this.outputTab) > -1) {
-      return "two column";
+    if (['compacted', 'flattened', 'framed'].indexOf(this.outputTab) > -1) {
+      return 'two column';
     }
-    return "";
+    return '';
   },
   get permalinkURL() {
     const url = new URL(window.location);
     const hash = new URLSearchParams();
-    hash.set("json-ld", JSON.stringify(this.doc));
-    if (this.contextDoc && JSON.stringify(this.contextDoc) !== "{}") {
-      hash.set("context", JSON.stringify(this.contextDoc));
+    hash.set('json-ld', JSON.stringify(this.doc));
+    if (this.contextDoc && JSON.stringify(this.contextDoc) !== '{}') {
+      hash.set('context', JSON.stringify(this.contextDoc));
     }
-    if (this.frameDoc && JSON.stringify(this.frameDoc) !== "{}") {
-      hash.set("frame", JSON.stringify(this.frameDoc));
+    if (this.frameDoc && JSON.stringify(this.frameDoc) !== '{}') {
+      hash.set('frame', JSON.stringify(this.frameDoc));
     }
-    hash.set("startTab", `tab-${this.outputTab}`);
+    hash.set('startTab', `tab-${this.outputTab}`);
     url.hash = hash.toString();
     return url.toString();
   },
   get sideDoc() {
-    if (this.outputTab === "framed") {
-      return "frameDoc";
+    if (this.outputTab === 'framed') {
+      return 'frameDoc';
     } else {
-      return "contextDoc";
+      return 'contextDoc';
     }
   },
   get sideEditor() {
-    if (this.outputTab === "framed") {
+    if (this.outputTab === 'framed') {
       return this.frameEditor;
     } else {
       return this.contextEditor;
     }
   },
   get sideEditorURLFieldPlaceholderText() {
-    if (this.outputTab === "framed") {
-      return "Frame URL";
+    if (this.outputTab === 'framed') {
+      return 'Frame URL';
     } else {
-      return "Context URL";
+      return 'Context URL';
     }
   },
   copyPermalink() {
     const url = this.permalinkURL;
-    navigator.clipboard
-      .writeText(url)
-      .then(() => {
-        console.log("Permalink copied to clipboard:", url);
-      })
-      .catch((err) => {
-        console.error("Failed to copy permalink:", err);
-      });
+    navigator.clipboard.writeText(url).then(() => {
+      console.log('Permalink copied to clipboard:', url);
+    }).catch(err => {
+      console.error('Failed to copy permalink:', err);
+    });
   },
   // methods
   async retrieveDoc(_editor, docVar, url) {
@@ -503,8 +423,8 @@ window.app = createApp({
       this[docVar] = await rv.json();
       setEditorValue(_editor, this[docVar]);
       // clear the remoteDocURL to avoid confusion around state
-      this.remoteDocURL = "";
-      this.remoteSideDocURL = "";
+      this.remoteDocURL = '';
+      this.remoteSideDocURL = '';
     } catch (err) {
       this.parseError = err;
     }
@@ -514,7 +434,7 @@ window.app = createApp({
     this.doc = await rv.json();
     setEditorValue(this.mainEditor, this.doc);
     // TODO: make this less of a hack...so we can provide other frames
-    if (file === "library.jsonld") {
+    if (file === 'library.jsonld') {
       const frame = await fetch(`/examples/playground/library-frame.jsonld`);
       this.frameDoc = await frame.json();
       setEditorValue(this.frameEditor, this.frameDoc);
@@ -529,134 +449,116 @@ window.app = createApp({
     if (value) this.outputTab = value;
     let context = this.contextDoc;
     switch (this.outputTab) {
-      // expanded quando viene chiamato setEditorValue prende sempre il valore di this.options.formatMode, quindi se è impostato su yaml
+      // expanded when setEditorValue is called always takes the value of this.options.formatMode, so if it is set to yaml otherwise json
       case "expanded":
         // TODO: this should happen elsewhere...like a watcher
         try {
           const expanded = await jsonld.expand(this.doc, this.options);
           setEditorValue(readOnlyEditor, expanded, this.options.formatMode);
           this.parseError = {};
-        } catch (err) {
+        } catch(err) {
           this.parseError = err;
         }
         break;
-      case "compacted":
-        if (JSON.stringify(context) === "{}" && "@context" in this.doc) {
+      case 'compacted':
+        if (JSON.stringify(context) === '{}' && '@context' in this.doc) {
           // no context set yet, so copy in the main document's
           context = {
-            "@context": this.doc["@context"],
+            '@context': this.doc['@context']
           };
           this.contextDoc = context;
           setEditorValue(this.sideEditor, this.contextDoc);
         }
         try {
-          const compacted = await jsonld.compact(
-            this.doc,
-            { "@context": context["@context"] || {} },
-            this.options,
-          );
+          const compacted = await jsonld.compact(this.doc, {'@context': context['@context'] || {}}, this.options);
           setEditorValue(readOnlyEditor, compacted);
           this.parseError = {};
-        } catch (err) {
+        } catch(err) {
           this.parseError = err;
         }
         break;
-      case "flattened":
-        if (JSON.stringify(context) === "{}" && "@context" in this.doc) {
+      case 'flattened':
+        if (JSON.stringify(context) === '{}' && '@context' in this.doc) {
           // no context set yet, so copy in the main document's
           context = {
-            "@context": this.doc["@context"],
+            '@context': this.doc['@context']
           };
           this.contextDoc = context;
           setEditorValue(this.sideEditor, this.contextDoc);
         }
         try {
-          const flattened = await jsonld.flatten(
-            this.doc,
-            { "@context": context["@context"] || {} },
-            this.options,
-          );
+          const flattened = await jsonld.flatten(this.doc, {'@context': context['@context'] || {}}, this.options);
           setEditorValue(readOnlyEditor, flattened);
           this.parseError = {};
-        } catch (err) {
+        } catch(err) {
           this.parseError = err;
         }
         break;
-      case "framed":
+      case 'framed':
         try {
-          const framed = await jsonld.frame(
-            this.doc,
-            this.frameDoc,
-            this.options,
-          );
+          const framed = await jsonld.frame(this.doc, this.frameDoc, this.options);
           setEditorValue(readOnlyEditor, framed);
           this.parseError = {};
-        } catch (err) {
+        } catch(err) {
           this.parseError = err;
         }
         break;
-      case "nquads":
+      case 'nquads':
         // TODO: this should happen elsewhere...like a watcher
         try {
           const output = await jsonld.toRDF(this.doc, {
-            format: "application/n-quads",
-            ...this.options,
+            format: 'application/n-quads',
+            ...this.options
           });
           setEditorValue(readOnlyEditor, output);
           this.parseError = {};
-        } catch (err) {
+        } catch(err) {
           this.parseError = err;
         }
         break;
-      case "canonized":
+      case 'canonized':
         // TODO: this should happen elsewhere...like a watcher
         try {
           const output = await jsonld.canonize(this.doc, {
-            format: "application/n-quads",
-            ...{ ...this.options, ...{ safe: true } },
+            format: 'application/n-quads', ...{...this.options, ...{safe: true}}
           });
           setEditorValue(readOnlyEditor, output);
           this.parseError = {};
-        } catch (err) {
+        } catch(err) {
           this.parseError = err;
         }
         break;
-      case "table":
+      case 'table':
         // TODO: this should happen elsewhere...like a watcher
         try {
           const output = await jsonld.toRDF(this.doc, this.options);
           this.tableQuads = output;
           this.parseError = {};
-        } catch (err) {
+        } catch(err) {
           this.parseError = err;
         }
         break;
-      case "yamlld":
+      case 'yamlld':
         this.yamlLD = YAML.stringify(this.doc);
-        setEditorValue(readOnlyEditor, this.yamlLD, "yaml");
+        setEditorValue(readOnlyEditor, this.yamlLD, 'yaml');
         break;
-      case "cborld":
+      case 'cborld':
         try {
           this.cborLD.jsonldSize = JSON.stringify(this.doc).length;
           this.cborLD.bytes = await cborld.encode({
             jsonldDocument: this.doc,
             documentLoader: jsonld.documentLoader,
             // use standard compression (set to `0` to use no compression)
-            registryEntryId: 1,
+            registryEntryId: 1
           });
           this.cborLD.size = this.cborLD.bytes.length;
-          this.cborLD.hex = Array.from(this.cborLD.bytes, (byte) =>
-            byte.toString(16).padStart(2, "0"),
-          ).join("");
-          this.cborLD.percentage = Math.floor(
-            ((this.cborLD.jsonldSize - this.cborLD.size) /
-              this.cborLD.jsonldSize) *
-              100,
-          );
+          this.cborLD.hex = Array.from(this.cborLD.bytes, byte =>
+            byte.toString(16).padStart(2, '0')).join('');
+          this.cborLD.percentage =
+            Math.floor(((this.cborLD.jsonldSize - this.cborLD.size) / this.cborLD.jsonldSize) * 100);
           this.cborLD.diagnostics = cbor2.diagnose(this.cborLD.bytes, {
-            pretty: true,
-          });
-          setEditorValue(readOnlyEditor, this.cborLD.diagnostics, "cbor");
+            pretty: true})
+          setEditorValue(readOnlyEditor, this.cborLD.diagnostics, 'cbor');
           this.parseError = {};
         } catch (err) {
           // TODO: currently, the editor keeps it's old value...unupdated...
@@ -669,49 +571,41 @@ window.app = createApp({
     }
   },
   initContextEditor() {
-    this.contextEditor = initEditor.call(
-      this,
-      "context-editor",
-      this.contextDoc,
-      "contextDoc",
-    );
+    this.contextEditor = initEditor.call(this, 'context-editor',
+      this.contextDoc, 'contextDoc');
   },
   initFrameEditor() {
-    this.frameEditor = initEditor.call(
-      this,
-      "frame-editor",
-      this.frameDoc,
-      "frameDoc",
-    );
+    this.frameEditor = initEditor.call(this, 'frame-editor', this.frameDoc,
+      'frameDoc');
   },
   initMainEditor() {
-    this.mainEditor = initEditor.call(this, "editor", "", "doc");
+    this.mainEditor = initEditor.call(this, 'editor', '', 'doc');
   },
   copyContext() {
     this.contextDoc = {
-      "@context": this.doc["@context"],
+      '@context': this.doc['@context']
     };
     setEditorValue(this.contextEditor, this.contextDoc);
   },
   async gatherHash() {
     const url = new URL(window.location);
     const hash = new URLSearchParams(url?.hash.slice(1));
-    this.contextDoc = JSON.parse(hash.get("context")) || {};
+    this.contextDoc = JSON.parse(hash.get('context')) || {};
     setEditorValue(this.contextEditor, this.contextDoc);
-    this.frameDoc = JSON.parse(hash.get("frame")) || {};
+    this.frameDoc = JSON.parse(hash.get('frame')) || {};
     setEditorValue(this.frameEditor, this.frameDoc);
     // the `json-ld` parameter can be JSON or a URL
-    const jsonLdOrUrl = hash.get("json-ld");
+    const jsonLdOrUrl = hash.get('json-ld');
     try {
       this.doc = JSON.parse(jsonLdOrUrl) || this.doc;
       setEditorValue(this.mainEditor, this.doc);
     } catch {
       this.remoteDocURL = jsonLdOrUrl;
-      await this.retrieveDoc(this.mainEditor, "doc", this.remoteDocURL);
+      await this.retrieveDoc(this.mainEditor, 'doc', this.remoteDocURL);
     }
-    if (hash.get("copyContext") === "true") {
+    if (hash.get('copyContext') === 'true') {
       this.copyContext();
     }
-    this.outputTab = hash.get("startTab")?.slice(4) || this.outputTab;
-  },
+    this.outputTab = hash.get('startTab')?.slice(4) || this.outputTab;
+  }
 }).mount();

--- a/playground/next/editor.mjs
+++ b/playground/next/editor.mjs
@@ -1,41 +1,41 @@
 /* globals: jsonld */
 
-import {EditorView, basicSetup} from 'codemirror';
-import {createApp} from "petite-vue";
-import {Compartment, EditorState, RangeSetBuilder} from '@codemirror/state'
-import {indentWithTab} from '@codemirror/commands';
-import {json, jsonLanguage, jsonParseLinter} from "@codemirror/lang-json";
-import {syntaxTree, StreamLanguage} from '@codemirror/language';
-import {ntriples} from '@codemirror/legacy-modes/mode/ntriples';
-import {Decoration, keymap, ViewPlugin} from '@codemirror/view';
-import {linter} from '@codemirror/lint';
-import YAML from 'yaml';
-import {yaml} from '@codemirror/lang-yaml';
-import * as cborld from '@digitalbazaar/cborld';
-import * as cbor2 from 'cbor2';
-import jsonld from 'jsonld';
+import { EditorView, basicSetup } from "codemirror";
+import { createApp } from "petite-vue";
+import { Compartment, EditorState, RangeSetBuilder } from "@codemirror/state";
+import { indentWithTab } from "@codemirror/commands";
+import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
+import { syntaxTree, StreamLanguage } from "@codemirror/language";
+import { ntriples } from "@codemirror/legacy-modes/mode/ntriples";
+import { Decoration, keymap, ViewPlugin } from "@codemirror/view";
+import { linter } from "@codemirror/lint";
+import YAML from "yaml";
+import { yaml } from "@codemirror/lang-yaml";
+import * as cborld from "@digitalbazaar/cborld";
+import * as cbor2 from "cbor2";
+import jsonld from "jsonld";
 
 // Setup JSON-LD documentLoader
 const xhrDocumentLoader = jsonld.documentLoaders.xhr();
 // FIXME: add UI to let users control and set context mapping
-jsonld.documentLoader = function(url) {
+jsonld.documentLoader = function (url) {
   // rewrite URLs that we know have secure JSON-LD Contexts
-  if(url === 'http://schema.org/' || url === 'http://schema.org') {
-    url = 'https://schema.org/';
+  if (url === "http://schema.org/" || url === "http://schema.org") {
+    url = "https://schema.org/";
   }
 
   // if a non-HTTPS URL, use the proxy since we run in HTTPS only mode
-  if(!url.startsWith('https://')) {
+  if (!url.startsWith("https://")) {
     url = [
       location.protocol,
-      '//',
+      "//",
       location.host,
       // NOTE: using hard-coded path so file can be shared with dev page
       //location.pathname,
-      '/playground/',
-      'proxy?url=',
-      url
-    ].join('');
+      "/playground/",
+      "proxy?url=",
+      url,
+    ].join("");
   }
 
   return xhrDocumentLoader(url);
@@ -44,40 +44,107 @@ jsonld.documentLoader = function(url) {
 const jsonLdAtTerms = {
   // JSON-LD terms usable as keys
   keys: [
-    { label: "@context", type: "keyword", info: "Defines the JSON-LD context", boost: 90 },
-    { label: "@id", type: "keyword", info: "Specifies the unique identifier of an entity", boost: 80 },
-    { label: "@type", type: "keyword", info: "Defines the type of an entity", boost: 70 },
-    { label: "@value", type: "keyword", info: "Represents the value of a node" },
-    { label: "@language", type: "keyword", info: "Specifies the language of a string value" },
+    {
+      label: "@context",
+      type: "keyword",
+      info: "Defines the JSON-LD context",
+      boost: 90,
+    },
+    {
+      label: "@id",
+      type: "keyword",
+      info: "Specifies the unique identifier of an entity",
+      boost: 80,
+    },
+    {
+      label: "@type",
+      type: "keyword",
+      info: "Defines the type of an entity",
+      boost: 70,
+    },
+    {
+      label: "@value",
+      type: "keyword",
+      info: "Represents the value of a node",
+    },
+    {
+      label: "@language",
+      type: "keyword",
+      info: "Specifies the language of a string value",
+    },
     { label: "@graph", type: "keyword", info: "Represents a named graph" },
     { label: "@list", type: "keyword", info: "Denotes an ordered list" },
     { label: "@set", type: "keyword", info: "Denotes an unordered set" },
     { label: "@reverse", type: "keyword", info: "Defines reverse properties" },
-    { label: "@index", type: "keyword", info: "Specifies an index for ordered data" },
+    {
+      label: "@index",
+      type: "keyword",
+      info: "Specifies an index for ordered data",
+    },
     { label: "@base", type: "keyword", info: "Defines the base IRI" },
-    { label: "@vocab", type: "keyword", info: "Defines the default vocabulary" },
-    { label: "@container", type: "keyword", info: "Specifies container types for properties" },
+    {
+      label: "@vocab",
+      type: "keyword",
+      info: "Defines the default vocabulary",
+    },
+    {
+      label: "@container",
+      type: "keyword",
+      info: "Specifies container types for properties",
+    },
     { label: "@nest", type: "keyword", info: "Allows nesting of properties" },
     { label: "@prefix", type: "keyword", info: "Defines a prefix mapping" },
-    { label: "@propagate", type: "keyword", info: "Controls context propagation" },
+    {
+      label: "@propagate",
+      type: "keyword",
+      info: "Controls context propagation",
+    },
     { label: "@protected", type: "keyword", info: "Prevents term overrides" },
-    { label: "@version", type: "keyword", info: "Specifies the JSON-LD version" },
-    { label: "@none", type: "keyword", info: "Denote as not part of the index" }
+    {
+      label: "@version",
+      type: "keyword",
+      info: "Specifies the JSON-LD version",
+    },
+    {
+      label: "@none",
+      type: "keyword",
+      info: "Denote as not part of the index",
+    },
   ],
   // JSON-LD terms usable as values
   values: [
-    { label: "@id", type: "keyword", info: "The value of this term is an IRI.", parent: "@type" },
-    { label: "@json", type: "keyword", info: "Specifies the type as a JSON literal (`rdf:JSON`).", parent: "@type" },
-    { label: "@list", type: "keyword", info: "Denotes an ordered list", parent: "@container" },
-    { label: "@set", type: "keyword", info: "Denotes an unordered set", parent: "@container" },
-    { label: "@none", type: "keyword", info: "", parent: "@type" }
-  ]
+    {
+      label: "@id",
+      type: "keyword",
+      info: "The value of this term is an IRI.",
+      parent: "@type",
+    },
+    {
+      label: "@json",
+      type: "keyword",
+      info: "Specifies the type as a JSON literal (`rdf:JSON`).",
+      parent: "@type",
+    },
+    {
+      label: "@list",
+      type: "keyword",
+      info: "Denotes an ordered list",
+      parent: "@container",
+    },
+    {
+      label: "@set",
+      type: "keyword",
+      info: "Denotes an unordered set",
+      parent: "@container",
+    },
+    { label: "@none", type: "keyword", info: "", parent: "@type" },
+  ],
 };
 
-// TODO: the next two functions could probably become a petite-vue component
+// editorListener ora riesce a gestire sia JSON che YAML a seconda dell'impostazione di `options.formatMode`
 function editorListener(docName) {
-  let changes = []; // keep the changes as a list; then pick the last one
-  let timer; // we only want one timer, once the last one is done, use the result
+  let changes = [];
+  let timer;
   function debounce(fn, delay) {
     return (...args) => {
       clearTimeout(timer);
@@ -89,22 +156,26 @@ function editorListener(docName) {
     if (update.docChanged) {
       changes.push(update.state.doc.toString());
       debounce((docName) => {
-        // set the global `doc` to the latest string from the editor
-        const latestChange = changes[changes.length-1];
-        if (latestChange === '') {
-          this[docName] = '';
+        const latestChange = changes[changes.length - 1];
+        if (latestChange === "") {
+          this[docName] = "";
+          this.rawDoc = "";
           this.parseError = {};
-          setEditorValue(readOnlyEditor, '');
+          setEditorValue(readOnlyEditor, "");
           return;
         } else {
+          this.rawDoc = latestChange;
           try {
-            const parsed = JSON.parse(latestChange);
+            const parsed =
+              this.options.formatMode === "yaml"
+                ? YAML.parse(latestChange)
+                : JSON.parse(latestChange);
             this[docName] = parsed;
             this.parseError = {};
             this.setOutputTab(this.outputTab);
           } catch (err) {
             this.parseError = err;
-          };
+          }
         }
       }, 1000).call(this, docName);
     }
@@ -147,28 +218,32 @@ function completeJSONLDTerms(context) {
 
   const textBefore = context.state.sliceDoc(nodeBefore.from, context.pos);
   const tagBefore = /@\w*$/.exec(textBefore);
-  if (!tagBefore && !context.explicit
-      || (nodeBefore.name === '}' && nodeBefore._parent?.name === 'Object')
-      || (nodeBefore.name === 'JsonText')) {
+  if (
+    (!tagBefore && !context.explicit) ||
+    (nodeBefore.name === "}" && nodeBefore._parent?.name === "Object") ||
+    nodeBefore.name === "JsonText"
+  ) {
     return null;
   }
 
   // set the default list of term options
   let options = jsonLdAtTerms.keys.map(termsInQuotes);
-  if (nodeBefore._parent?.name === 'Property') {
+  if (nodeBefore._parent?.name === "Property") {
     switch (nodeBefore.name) {
-      case 'String':
-      case ':':
+      case "String":
+      case ":":
         const termParents = jsonLdAtTerms.values.map((term) => term.parent);
         if (termParents.indexOf(nearestProperty) > -1) {
           // limit the term list when we know we can
-          options = jsonLdAtTerms.values.filter((term) => term?.parent === nearestProperty);
+          options = jsonLdAtTerms.values.filter(
+            (term) => term?.parent === nearestProperty,
+          );
         } else {
           options = jsonLdAtTerms.values;
         }
-        if (nodeBefore.name === ':') options.map(termsInQuotes);
+        if (nodeBefore.name === ":") options.map(termsInQuotes);
         break;
-      case 'PropertyName':
+      case "PropertyName":
         // TODO: not sure why `apply` from termsInQuotes hangs around sometimes
         // ...but it does...so this removes the `apply` value if present
         options = jsonLdAtTerms.keys.map((term) => {
@@ -176,227 +251,246 @@ function completeJSONLDTerms(context) {
           return term;
         });
         break;
-      case 'Object':
+      case "Object":
         // we're not inside of quotation marks...so add them also
         options = jsonLdAtTerms.keys.map(termsInQuotes);
         break;
     }
-  } else if (nodeBefore._parent?.name === 'Object') {
-    if (nodeBefore.name === '{' || nodeBefore.name === 'Property') {
+  } else if (nodeBefore._parent?.name === "Object") {
+    if (nodeBefore.name === "{" || nodeBefore.name === "Property") {
       options = jsonLdAtTerms.keys.map(termsInQuotes);
     }
   }
 
   return {
     from: tagBefore ? nodeBefore.from + tagBefore.index : context.pos,
-    options
+    options,
   };
 }
 
 const jsonLdCompletions = jsonLanguage.data.of({
-  autocomplete: completeJSONLDTerms
+  autocomplete: completeJSONLDTerms,
 });
 
 // Create a decoration that applies a CSS class for JSON‑LD property names
-const jsonLdPropertyDecoration = Decoration.mark({ class: 'cm-jsonld-property' });
+const jsonLdPropertyDecoration = Decoration.mark({
+  class: "cm-jsonld-property",
+});
 
 const jsonLdKeywords = new Set(
-  [].concat(...Object.values(jsonLdAtTerms)).map((term) => term.label));
+  [].concat(...Object.values(jsonLdAtTerms)).map((term) => term.label),
+);
 
 /**
  * A view plugin that scans the document for PropertyName nodes and, if their
  * content (without quotes) is a JSON‑LD keyword, adds a decoration to style it.
  */
-const jsonLdKeywordHighlighter = ViewPlugin.fromClass(class {
-  constructor(view) {
-    this.decorations = this.buildDecorations(view);
-  }
-
-  update(update) {
-    if (update.docChanged || update.viewportChanged) {
-      this.decorations = this.buildDecorations(update.view);
+const jsonLdKeywordHighlighter = ViewPlugin.fromClass(
+  class {
+    constructor(view) {
+      this.decorations = this.buildDecorations(view);
     }
-  }
 
-  buildDecorations(view) {
-    let builder = new RangeSetBuilder();
-    let tree = syntaxTree(view.state);
-    // Only inspect nodes in the current viewport
-    tree.iterate({
-      from: view.viewport.from,
-      to: view.viewport.to,
-      enter: (node) => {
-        // Look for property names (as defined by lang-json)
-        if (node.name === "PropertyName" || node.name === "String") {
-          let token = view.state.doc.sliceString(node.from, node.to);
-          // Remove the surrounding quotes, if any
-          if (token.startsWith('"') && token.endsWith('"')) {
-            token = token.slice(1, -1);
-          }
-          if (jsonLdKeywords.has(token)) {
-            builder.add(node.from, node.to, jsonLdPropertyDecoration);
-          }
-        }
+    update(update) {
+      if (update.docChanged || update.viewportChanged) {
+        this.decorations = this.buildDecorations(update.view);
       }
-    });
-    return builder.finish();
-  }
+    }
 
-  destroy() {}
-}, {
-  decorations: v => v.decorations
-});
+    buildDecorations(view) {
+      let builder = new RangeSetBuilder();
+      let tree = syntaxTree(view.state);
+      // Only inspect nodes in the current viewport
+      tree.iterate({
+        from: view.viewport.from,
+        to: view.viewport.to,
+        enter: (node) => {
+          // Look for property names (as defined by lang-json)
+          if (node.name === "PropertyName" || node.name === "String") {
+            let token = view.state.doc.sliceString(node.from, node.to);
+            // Remove the surrounding quotes, if any
+            if (token.startsWith('"') && token.endsWith('"')) {
+              token = token.slice(1, -1);
+            }
+            if (jsonLdKeywords.has(token)) {
+              builder.add(node.from, node.to, jsonLdPropertyDecoration);
+            }
+          }
+        },
+      });
+      return builder.finish();
+    }
+
+    destroy() {}
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
 
 // A base theme for our decoration
 const jsonLdHighlightTheme = EditorView.baseTheme({
-  '.cm-jsonld-property': {
-    color: '#333',
-    fontWeight: 'bold'
-  }
+  ".cm-jsonld-property": {
+    color: "#333",
+    fontWeight: "bold",
+  },
 });
 
+// initEditor ora riesce a gestire sia JSON che YAML a seconda dell'impostazione di `options.formatMode`
 function initEditor(id, content, varName) {
+  const lang = this.options.formatMode;
+  const languageExtension = lang === "yaml" ? yaml() : json();
+  const linterExtension = lang === "yaml" ? [] : linter(jsonParseLinter());
+
   return new EditorView({
     parent: document.getElementById(id),
-    doc: (content === 'object' ? JSON.stringify(content, null, 2) : ''),
+    doc: typeof content === "object" ? JSON.stringify(content, null, 2) : "",
     extensions: [
       basicSetup,
       keymap.of([indentWithTab]),
-      jsonLanguage,
+      language.of(languageExtension),
       jsonLdKeywordHighlighter,
       jsonLdHighlightTheme,
-      linter(jsonParseLinter()),
+      ...linterExtension,
       jsonLdCompletions,
-      editorListener.call(this, varName)
-    ]
+      editorListener.call(this, varName),
+    ],
   });
 }
 
 const language = new Compartment();
 
 const readOnlyEditor = new EditorView({
-  parent: document.getElementById('read-only-editor'),
-  doc: '',
+  parent: document.getElementById("read-only-editor"),
+  doc: "",
   extensions: [
     basicSetup,
     language.of(json()),
     EditorState.readOnly.of(true),
     EditorView.editable.of(false),
-    EditorView.contentAttributes.of({tabindex: '0'})
-  ]
+    EditorView.contentAttributes.of({ tabindex: "0" }),
+  ],
 });
 
+// setEditorValue ora riesce a gestire sia JSON che YAML a seconda dell'impostazione di `options.formatMode`
 function setEditorValue(_editor, doc, lang) {
-  // TODO: this runs more often than it should (because v-effect); maybe debounce
   if (_editor) {
-    // set the correct language
-    let effects = language.reconfigure(json());
-    if (lang === 'yaml') effects = language.reconfigure(yaml());
-    else effects = language.reconfigure(StreamLanguage.define(ntriples));
+    let languageExtension;
+    let insert;
+
+    if (lang === "yaml") {
+      languageExtension = yaml();
+      insert = typeof doc === "object" ? YAML.stringify(doc) : doc;
+    } else if (typeof doc === "object" || lang === "json") {
+      languageExtension = json();
+      insert = typeof doc === "object" ? JSON.stringify(doc, null, 2) : doc;
+    } else {
+      languageExtension = StreamLanguage.define(ntriples);
+      insert = doc;
+    }
 
     _editor.dispatch({
       changes: {
         from: 0,
         to: _editor.state.doc.length,
-        insert: typeof(doc) === 'object'
-          ? JSON.stringify(doc, null, 2)
-          : doc
+        insert,
       },
-      // set the correct language
-      effects: language.reconfigure(typeof(doc) === 'object'
-        ? json()
-        : StreamLanguage.define(ntriples))
+      effects: language.reconfigure(languageExtension),
     });
   }
 }
 
 window.app = createApp({
-  doc: '',
+  doc: "",
   contextDoc: {},
   frameDoc: {},
   tableQuads: {},
-  yamlLD: '',
+  yamlLD: "",
   cborLD: {
     bytes: {},
-    hex: '',
+    hex: "",
     jsonldSize: 0,
     size: 0,
-    percentage: 0
+    percentage: 0,
   },
-  remoteDocURL: '',
-  remoteSideDocURL: '',
-  message: {type: '', text: ''},
+  remoteDocURL: "",
+  remoteSideDocURL: "",
+  message: { type: "", text: "" },
   parseError: {},
-  inputTab: 'json-ld',
-  outputTab: 'expanded',
+  inputTab: "json-ld",
+  outputTab: "expanded",
   options: {
-    processingMode: 'json-ld-1.1',
-    base: '',
+    processingMode: "json-ld-1.1",
+    formatMode: "yaml",
+    base: "",
     compactArrays: true,
     compactToRelative: true,
-    rdfDirection: '',
-    safe: false
+    rdfDirection: "",
+    safe: false,
   },
   tabs: {
-    expanded: {icon: 'expand alternate', label: 'Expanded'},
-    compacted: {icon: 'compress alternate', label: 'Compacted'},
-    flattened: {icon: 'bars', label: 'Flattened'},
-    framed: {icon: 'crop alternate', label: 'Framed'},
-    nquads: {icon: 'rdf-icon-rdf', label: 'N-Quads'},
-    canonized: {icon: 'archive', label: 'Canonized'},
-    table: {icon: 'th', label: 'Table'},
-    yamlld: {icon: 'stream', label: 'YAML-LD'},
-    cborld: {icon: 'robot', label: 'CBOR-LD'}
+    expanded: { icon: "expand alternate", label: "Expanded" },
+    compacted: { icon: "compress alternate", label: "Compacted" },
+    flattened: { icon: "bars", label: "Flattened" },
+    framed: { icon: "crop alternate", label: "Framed" },
+    nquads: { icon: "rdf-icon-rdf", label: "N-Quads" },
+    canonized: { icon: "archive", label: "Canonized" },
+    table: { icon: "th", label: "Table" },
+    yamlld: { icon: "stream", label: "YAML-LD" },
+    cborld: { icon: "robot", label: "CBOR-LD" },
   },
   // computed
   get editorColumns() {
-    if (['compacted', 'flattened', 'framed'].indexOf(this.outputTab) > -1) {
-      return 'two column';
+    if (["compacted", "flattened", "framed"].indexOf(this.outputTab) > -1) {
+      return "two column";
     }
-    return '';
+    return "";
   },
   get permalinkURL() {
     const url = new URL(window.location);
     const hash = new URLSearchParams();
-    hash.set('json-ld', JSON.stringify(this.doc));
-    if (this.contextDoc && JSON.stringify(this.contextDoc) !== '{}') {
-      hash.set('context', JSON.stringify(this.contextDoc));
+    hash.set("json-ld", JSON.stringify(this.doc));
+    if (this.contextDoc && JSON.stringify(this.contextDoc) !== "{}") {
+      hash.set("context", JSON.stringify(this.contextDoc));
     }
-    if (this.frameDoc && JSON.stringify(this.frameDoc) !== '{}') {
-      hash.set('frame', JSON.stringify(this.frameDoc));
+    if (this.frameDoc && JSON.stringify(this.frameDoc) !== "{}") {
+      hash.set("frame", JSON.stringify(this.frameDoc));
     }
-    hash.set('startTab', `tab-${this.outputTab}`);
+    hash.set("startTab", `tab-${this.outputTab}`);
     url.hash = hash.toString();
     return url.toString();
   },
   get sideDoc() {
-    if (this.outputTab === 'framed') {
-      return 'frameDoc';
+    if (this.outputTab === "framed") {
+      return "frameDoc";
     } else {
-      return 'contextDoc';
+      return "contextDoc";
     }
   },
   get sideEditor() {
-    if (this.outputTab === 'framed') {
+    if (this.outputTab === "framed") {
       return this.frameEditor;
     } else {
       return this.contextEditor;
     }
   },
   get sideEditorURLFieldPlaceholderText() {
-    if (this.outputTab === 'framed') {
-      return 'Frame URL';
+    if (this.outputTab === "framed") {
+      return "Frame URL";
     } else {
-      return 'Context URL';
+      return "Context URL";
     }
   },
   copyPermalink() {
     const url = this.permalinkURL;
-    navigator.clipboard.writeText(url).then(() => {
-      console.log('Permalink copied to clipboard:', url);
-    }).catch(err => {
-      console.error('Failed to copy permalink:', err);
-    });
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        console.log("Permalink copied to clipboard:", url);
+      })
+      .catch((err) => {
+        console.error("Failed to copy permalink:", err);
+      });
   },
   // methods
   async retrieveDoc(_editor, docVar, url) {
@@ -409,8 +503,8 @@ window.app = createApp({
       this[docVar] = await rv.json();
       setEditorValue(_editor, this[docVar]);
       // clear the remoteDocURL to avoid confusion around state
-      this.remoteDocURL = '';
-      this.remoteSideDocURL = '';
+      this.remoteDocURL = "";
+      this.remoteSideDocURL = "";
     } catch (err) {
       this.parseError = err;
     }
@@ -420,7 +514,7 @@ window.app = createApp({
     this.doc = await rv.json();
     setEditorValue(this.mainEditor, this.doc);
     // TODO: make this less of a hack...so we can provide other frames
-    if (file === 'library.jsonld') {
+    if (file === "library.jsonld") {
       const frame = await fetch(`/examples/playground/library-frame.jsonld`);
       this.frameDoc = await frame.json();
       setEditorValue(this.frameEditor, this.frameDoc);
@@ -435,115 +529,134 @@ window.app = createApp({
     if (value) this.outputTab = value;
     let context = this.contextDoc;
     switch (this.outputTab) {
-      case 'expanded':
+      // expanded quando viene chiamato setEditorValue prende sempre il valore di this.options.formatMode, quindi se è impostato su yaml
+      case "expanded":
         // TODO: this should happen elsewhere...like a watcher
         try {
           const expanded = await jsonld.expand(this.doc, this.options);
-          setEditorValue(readOnlyEditor, expanded);
+          setEditorValue(readOnlyEditor, expanded, this.options.formatMode);
           this.parseError = {};
-        } catch(err) {
+        } catch (err) {
           this.parseError = err;
         }
         break;
-      case 'compacted':
-        if (JSON.stringify(context) === '{}' && '@context' in this.doc) {
+      case "compacted":
+        if (JSON.stringify(context) === "{}" && "@context" in this.doc) {
           // no context set yet, so copy in the main document's
           context = {
-            '@context': this.doc['@context']
+            "@context": this.doc["@context"],
           };
           this.contextDoc = context;
           setEditorValue(this.sideEditor, this.contextDoc);
         }
         try {
-          const compacted = await jsonld.compact(this.doc, {'@context': context['@context'] || {}}, this.options);
+          const compacted = await jsonld.compact(
+            this.doc,
+            { "@context": context["@context"] || {} },
+            this.options,
+          );
           setEditorValue(readOnlyEditor, compacted);
           this.parseError = {};
-        } catch(err) {
+        } catch (err) {
           this.parseError = err;
         }
         break;
-      case 'flattened':
-        if (JSON.stringify(context) === '{}' && '@context' in this.doc) {
+      case "flattened":
+        if (JSON.stringify(context) === "{}" && "@context" in this.doc) {
           // no context set yet, so copy in the main document's
           context = {
-            '@context': this.doc['@context']
+            "@context": this.doc["@context"],
           };
           this.contextDoc = context;
           setEditorValue(this.sideEditor, this.contextDoc);
         }
         try {
-          const flattened = await jsonld.flatten(this.doc, {'@context': context['@context'] || {}}, this.options);
+          const flattened = await jsonld.flatten(
+            this.doc,
+            { "@context": context["@context"] || {} },
+            this.options,
+          );
           setEditorValue(readOnlyEditor, flattened);
           this.parseError = {};
-        } catch(err) {
+        } catch (err) {
           this.parseError = err;
         }
         break;
-      case 'framed':
+      case "framed":
         try {
-          const framed = await jsonld.frame(this.doc, this.frameDoc, this.options);
+          const framed = await jsonld.frame(
+            this.doc,
+            this.frameDoc,
+            this.options,
+          );
           setEditorValue(readOnlyEditor, framed);
           this.parseError = {};
-        } catch(err) {
+        } catch (err) {
           this.parseError = err;
         }
         break;
-      case 'nquads':
+      case "nquads":
         // TODO: this should happen elsewhere...like a watcher
         try {
           const output = await jsonld.toRDF(this.doc, {
-            format: 'application/n-quads',
-            ...this.options
+            format: "application/n-quads",
+            ...this.options,
           });
           setEditorValue(readOnlyEditor, output);
           this.parseError = {};
-        } catch(err) {
+        } catch (err) {
           this.parseError = err;
         }
         break;
-      case 'canonized':
+      case "canonized":
         // TODO: this should happen elsewhere...like a watcher
         try {
           const output = await jsonld.canonize(this.doc, {
-            format: 'application/n-quads', ...{...this.options, ...{safe: true}}
+            format: "application/n-quads",
+            ...{ ...this.options, ...{ safe: true } },
           });
           setEditorValue(readOnlyEditor, output);
           this.parseError = {};
-        } catch(err) {
+        } catch (err) {
           this.parseError = err;
         }
         break;
-      case 'table':
+      case "table":
         // TODO: this should happen elsewhere...like a watcher
         try {
           const output = await jsonld.toRDF(this.doc, this.options);
           this.tableQuads = output;
           this.parseError = {};
-        } catch(err) {
+        } catch (err) {
           this.parseError = err;
         }
         break;
-      case 'yamlld':
+      case "yamlld":
         this.yamlLD = YAML.stringify(this.doc);
-        setEditorValue(readOnlyEditor, this.yamlLD, 'yaml');
+        setEditorValue(readOnlyEditor, this.yamlLD, "yaml");
         break;
-      case 'cborld':
+      case "cborld":
         try {
           this.cborLD.jsonldSize = JSON.stringify(this.doc).length;
           this.cborLD.bytes = await cborld.encode({
             jsonldDocument: this.doc,
             documentLoader: jsonld.documentLoader,
             // use standard compression (set to `0` to use no compression)
-            registryEntryId: 1
+            registryEntryId: 1,
           });
           this.cborLD.size = this.cborLD.bytes.length;
-          this.cborLD.hex = Array.from(this.cborLD.bytes, byte =>
-            byte.toString(16).padStart(2, '0')).join('');
-          this.cborLD.percentage =
-            Math.floor(((this.cborLD.jsonldSize - this.cborLD.size) / this.cborLD.jsonldSize) * 100);
+          this.cborLD.hex = Array.from(this.cborLD.bytes, (byte) =>
+            byte.toString(16).padStart(2, "0"),
+          ).join("");
+          this.cborLD.percentage = Math.floor(
+            ((this.cborLD.jsonldSize - this.cborLD.size) /
+              this.cborLD.jsonldSize) *
+              100,
+          );
           this.cborLD.diagnostics = cbor2.diagnose(this.cborLD.bytes, {
-            pretty: true})
-          setEditorValue(readOnlyEditor, this.cborLD.diagnostics, 'cbor');
+            pretty: true,
+          });
+          setEditorValue(readOnlyEditor, this.cborLD.diagnostics, "cbor");
           this.parseError = {};
         } catch (err) {
           // TODO: currently, the editor keeps it's old value...unupdated...
@@ -556,41 +669,49 @@ window.app = createApp({
     }
   },
   initContextEditor() {
-    this.contextEditor = initEditor.call(this, 'context-editor',
-      this.contextDoc, 'contextDoc');
+    this.contextEditor = initEditor.call(
+      this,
+      "context-editor",
+      this.contextDoc,
+      "contextDoc",
+    );
   },
   initFrameEditor() {
-    this.frameEditor = initEditor.call(this, 'frame-editor', this.frameDoc,
-      'frameDoc');
+    this.frameEditor = initEditor.call(
+      this,
+      "frame-editor",
+      this.frameDoc,
+      "frameDoc",
+    );
   },
   initMainEditor() {
-    this.mainEditor = initEditor.call(this, 'editor', '', 'doc');
+    this.mainEditor = initEditor.call(this, "editor", "", "doc");
   },
   copyContext() {
     this.contextDoc = {
-      '@context': this.doc['@context']
+      "@context": this.doc["@context"],
     };
     setEditorValue(this.contextEditor, this.contextDoc);
   },
   async gatherHash() {
     const url = new URL(window.location);
     const hash = new URLSearchParams(url?.hash.slice(1));
-    this.contextDoc = JSON.parse(hash.get('context')) || {};
+    this.contextDoc = JSON.parse(hash.get("context")) || {};
     setEditorValue(this.contextEditor, this.contextDoc);
-    this.frameDoc = JSON.parse(hash.get('frame')) || {};
+    this.frameDoc = JSON.parse(hash.get("frame")) || {};
     setEditorValue(this.frameEditor, this.frameDoc);
     // the `json-ld` parameter can be JSON or a URL
-    const jsonLdOrUrl = hash.get('json-ld');
+    const jsonLdOrUrl = hash.get("json-ld");
     try {
       this.doc = JSON.parse(jsonLdOrUrl) || this.doc;
       setEditorValue(this.mainEditor, this.doc);
     } catch {
       this.remoteDocURL = jsonLdOrUrl;
-      await this.retrieveDoc(this.mainEditor, 'doc', this.remoteDocURL);
+      await this.retrieveDoc(this.mainEditor, "doc", this.remoteDocURL);
     }
-    if (hash.get('copyContext') === 'true') {
+    if (hash.get("copyContext") === "true") {
       this.copyContext();
     }
-    this.outputTab = hash.get('startTab')?.slice(4) || this.outputTab;
-  }
+    this.outputTab = hash.get("startTab")?.slice(4) || this.outputTab;
+  },
 }).mount();

--- a/playground/next/index.html
+++ b/playground/next/index.html
@@ -8,11 +8,8 @@ title: Next Playground
   <strong>NOTES</strong>:
   <ul>
     <li>
-      The playground uses
-      <a href="https://github.com/digitalbazaar/jsonld.js">jsonld.js</a> which
-      <a href="https://github.com/digitalbazaar/jsonld.js#conformance"
-        >conforms</a
-      >
+      The playground uses <a href="https://github.com/digitalbazaar/jsonld.js">jsonld.js</a>
+      which <a href="https://github.com/digitalbazaar/jsonld.js#conformance">conforms</a>
       to JSON-LD 1.1
       <a href="https://www.w3.org/TR/json-ld11/">syntax</a>
       (<a href="https://w3c.github.io/json-ld-syntax/errata/">errata</a>),
@@ -27,73 +24,45 @@ title: Next Playground
       <a href="https://vcplayground.org/">Verifiable Credentials Playground</a>
     </li>
   </ul>
-  <p>
-    Accesibility note: use <code>Esc</code> and then <code>Tab</code> (or
-    <code>Shift+Tab</code>) to navigate out of the editor.
-  </p>
+  <p>Accesibility note: use <code>Esc</code> and then <code>Tab</code> (or
+  <code>Shift+Tab</code>) to navigate out of the editor.</p>
 </div>
 
-<div
-  class="ui wide container"
-  v-scope
-  v-effect="setOutputTab()"
-  @vue:mounted="gatherHash()"
->
+<div class="ui wide container" v-scope v-effect="setOutputTab()" @vue:mounted="gatherHash()">
   <div class="ui buttons">
     <button class="ui large basic right pointing label">Examples</button>
-    <button
-      id="btn-person"
-      class="ui button"
-      @click="loadExample('person.jsonld')"
-    >
+    <button id="btn-person" class="ui button"
+      @click="loadExample('person.jsonld')">
       <i class="icon user"></i>
       <span>Person</span>
     </button>
-    <button
-      id="btn-event"
-      class="ui button"
-      @click="loadExample('event.jsonld')"
-    >
+    <button id="btn-event" class="ui button"
+      @click="loadExample('event.jsonld')">
       <i class="icon calendar"></i>
       <span>Event</span>
     </button>
-    <button
-      id="btn-place"
-      class="ui button"
-      @click="loadExample('place.jsonld')"
-    >
+    <button id="btn-place" class="ui button"
+      @click="loadExample('place.jsonld')">
       <i class="icon map marker"></i>
       <span>Place</span>
     </button>
-    <button
-      id="btn-product"
-      class="ui button"
-      @click="loadExample('product.jsonld')"
-    >
+    <button id="btn-product" class="ui button"
+      @click="loadExample('product.jsonld')">
       <i class="icon barcode"></i>
       <span>Product</span>
     </button>
-    <button
-      id="btn-recipe"
-      class="ui button"
-      @click="loadExample('recipe.jsonld')"
-    >
+    <button id="btn-recipe" class="ui button"
+      @click="loadExample('recipe.jsonld')">
       <i class="icon food"></i>
       <span>Recipe</span>
     </button>
-    <button
-      id="btn-library"
-      class="ui button"
-      @click="loadExample('library.jsonld')"
-    >
+    <button id="btn-library" class="ui button"
+      @click="loadExample('library.jsonld')">
       <i class="icon book"></i>
       <span>Library</span>
     </button>
-    <button
-      id="btn-activity"
-      class="ui button"
-      @click="loadExample('activity.jsonld')"
-    >
+    <button id="btn-activity" class="ui button"
+      @click="loadExample('activity.jsonld')">
       <i class="icon comment"></i>
       <span>Activity</span>
     </button>
@@ -103,15 +72,10 @@ title: Next Playground
     <button id="permalink" class="ui icon button" data-position="left center">
       <i class="icon linkify"></i>
     </button>
-    <div class="ui popup" style="min-width: 20em">
+    <div class="ui popup" style="min-width: 20em;">
       <div class="ui top attached label">Share this</div>
       <div class="ui fluid action input">
-        <input
-          type="text"
-          readonly
-          v-model="permalinkURL"
-          @focus="$event.target.select()"
-        />
+        <input type="text" readonly v-model="permalinkURL" @focus="$event.target.select()">
         <button class="ui icon button" @click="copyPermalink()">
           <i class="icon copy"></i>
         </button>
@@ -120,11 +84,7 @@ title: Next Playground
         This link is longer than 2kb, and may not work.
       </div>
     </div>
-    <button
-      id="keyboard-shortcuts"
-      class="ui icon button"
-      data-position="left center"
-    >
+    <button id="keyboard-shortcuts" class="ui icon button" data-position="left center">
       <i class="icon keyboard"></i>
     </button>
     <div class="ui popup">
@@ -150,127 +110,68 @@ title: Next Playground
     </div>
   </div>
   <div class="ui icon message" v-if="message.text" :class="message.type">
-    <i
-      class="icon"
-      :class="{
+    <i class="icon" :class="{
       'info circle': message.type == 'info',
       'check circle': message.type == 'success',
       'times circle': message.type == 'error',
       'exclamation triangle': message.type == 'warning'
-    }"
-    ></i>
+    }"></i>
     <div class="content">
       <div class="header" v-text="message.text"></div>
     </div>
   </div>
   <!-- main editor area -->
-  <div
-    class="ui one column wide compact grid container"
-    :class="[editorColumns]"
-  >
+  <div class="ui one column wide compact grid container" :class="[editorColumns]">
     <div class="column" :class="{ 'sixteen wide':  editorColumns == '' }">
       <div class="ui top attached tabular menu">
-        <div
-          :class="{ active: inputTab == 'json-ld' }"
-          class="item"
-          @click="inputTab = 'json-ld'"
-        >
-          <i class="pencil alternate icon"></i> JSON-LD Input
-        </div>
-        <div
-          :class="{ active: inputTab == 'options' }"
-          class="item"
-          @click="inputTab = 'options'"
-        >
-          <i class="wrench icon"></i> Options
-        </div>
+        <div :class="{ active: inputTab == 'json-ld' }" class="item" @click="inputTab = 'json-ld'"><i class="pencil alternate icon"></i> JSON-LD Input</div>
+        <div :class="{ active: inputTab == 'options' }" class="item" @click="inputTab = 'options'"><i class="wrench icon"></i> Options</div>
         <div class="right menu">
           <div class="item" style="padding-right: 0">
             <div class="ui icon input">
-              <input
-                type="text"
-                placeholder="Document URL"
-                v-model="remoteDocURL"
-                @keyup.enter="retrieveDoc(mainEditor, 'doc', remoteDocURL)"
-              />
-              <i
-                class="file link icon"
-                :class="{ disabled: remoteDocURL == '' }"
-                @click="retrieveDoc(mainEditor, 'doc', remoteDocURL)"
-              ></i>
+              <input type="text" placeholder="Document URL"
+                v-model="remoteDocURL" @keyup.enter="retrieveDoc(mainEditor, 'doc', remoteDocURL)">
+              <i class="file link icon" :class="{ disabled: remoteDocURL == '' }" @click="retrieveDoc(mainEditor, 'doc', remoteDocURL)"></i>
             </div>
           </div>
         </div>
       </div>
-      <div
-        class="ui bottom attached fitted resizable scrolling segment"
-        v-show="inputTab == 'json-ld'"
-      >
-        <div id="editor" @vue:mounted="initMainEditor()">
-          <!-- replaced by CodeMirror -->
-        </div>
+      <div class="ui bottom attached fitted resizable scrolling segment" v-show="inputTab == 'json-ld'">
+        <div id="editor" @vue:mounted="initMainEditor()"><!-- replaced by CodeMirror --></div>
       </div>
       <div class="ui bottom attached segment" v-show="inputTab == 'options'">
         <form class="ui form">
           <div class="inline fields" id="options-api-processingMode">
-            <label for="options-api-processingMode" class="two wide field"
-              >Processing Mode</label
-            >
+            <label for="options-api-processingMode" class="two wide field">Processing Mode</label>
             <div class="field">
               <div class="ui radio checkbox">
-                <input
-                  type="radio"
-                  id="options-api-processingMode-1-0"
-                  name="processingMode"
-                  value="json-ld-1.0"
-                  v-model="options.processingMode"
-                  @change="setOutputTab()"
-                />
+                <input type="radio" id="options-api-processingMode-1-0" name="processingMode" value="json-ld-1.0"
+                  v-model="options.processingMode" @change="setOutputTab()">
                 <label for="options-api-processingMode-1-0">JSON-LD 1.0</label>
               </div>
             </div>
             <div class="field">
               <div class="ui radio checkbox">
-                <input
-                  type="radio"
-                  id="options-api-processingMode-1-1"
-                  name="processingMode"
-                  value="json-ld-1.1"
-                  v-model="options.processingMode"
-                  @change="setOutputTab()"
-                />
+                <input type="radio" id="options-api-processingMode-1-1" name="processingMode" value="json-ld-1.1"
+                  v-model="options.processingMode" @change="setOutputTab()">
                 <label for="options-api-processingMode-1-1">JSON-LD 1.1</label>
               </div>
             </div>
           </div>
 
           <div class="inline fields" id="options-formatMode">
-            <label for="options-formatMode" class="two wide field"
-              >Format</label
-            >
+            <label for="options-formatMode" class="two wide field">Format</label>
             <div class="field">
               <div class="ui radio checkbox">
-                <input
-                  type="radio"
-                  id="options-formatMode-json"
-                  name="formatMode"
-                  value="json"
-                  v-model="options.formatMode"
-                  @change="setOutputTab()"
-                />
-                <label for="options-formatMode-json">JSON</label>
+                <input type="radio" id="options-formatMode-json" name="formatMode" value="json"
+                  v-model="options.formatMode" @change="setOutputTab()">
+                <label for="options-api-processingMode-1-0">JSON</label>
               </div>
             </div>
             <div class="field">
               <div class="ui radio checkbox">
-                <input
-                  type="radio"
-                  id="options-formatMode-yaml"
-                  name="formatMode"
-                  value="yaml"
-                  v-model="options.formatMode"
-                  @change="setOutputTab()"
-                />
+                <input type="radio" id="options-formatMode-yaml" name="formatMode" value="yaml"
+                  v-model="options.formatMode" @change="setOutputTab()">
                 <label for="options-formatMode-yaml">YAML</label>
               </div>
             </div>
@@ -279,13 +180,8 @@ title: Next Playground
           <div class="inline fields" id="options-api-base">
             <label for="options-api-base" class="two wide field">Base</label>
             <div class="sixteen wide field">
-              <input
-                type="text"
-                id="options-api-base-url"
-                placeholder="URL"
-                v-model="options.base"
-                @change="setOutputTab()"
-              />
+              <input type="text" id="options-api-base-url" placeholder="URL"
+                v-model="options.base" @change="setOutputTab()">
             </div>
           </div>
 
@@ -293,12 +189,8 @@ title: Next Playground
             <label class="two wide field"></label>
             <div class="field">
               <div class="ui checkbox">
-                <input
-                  type="checkbox"
-                  id="options-api-compactArrays"
-                  v-model="options.compactArrays"
-                  @change="setOutputTab()"
-                />
+                <input type="checkbox" id="options-api-compactArrays"
+                  v-model="options.compactArrays" @change="setOutputTab()">
                 <label for="options-api-compactArrays">Compact Arrays</label>
               </div>
             </div>
@@ -308,53 +200,28 @@ title: Next Playground
             <label class="two wide field"></label>
             <div class="field">
               <div class="ui checkbox">
-                <input
-                  type="checkbox"
-                  id="options-api-compactToRelative"
-                  v-model="options.compactToRelative"
-                  @change="setOutputTab()"
-                />
-                <label for="options-api-compactToRelative"
-                  >Compact To Relative</label
-                >
+                <input type="checkbox" id="options-api-compactToRelative"
+                  v-model="options.compactToRelative" @change="setOutputTab()">
+                <label for="options-api-compactToRelative">Compact To Relative</label>
               </div>
             </div>
           </div>
 
           <div class="field">
             <div class="inline fields" id="options-api-rdfDirection">
-              <label for="options-api-rdfDirection" class="two wide field"
-                >RDF Direction Mode</label
-              >
+              <label for="options-api-rdfDirection" class="two wide field">RDF Direction Mode</label>
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input
-                    type="radio"
-                    id="options-api-rdfDirection-default"
-                    name="rdfDirection"
-                    value=""
-                    checked
-                    v-model="options.rdfDirection"
-                    @change="setOutputTab()"
-                  />
-                  <label for="options-api-rdfDirection-default"
-                    >Default (null)</label
-                  >
+                  <input type="radio" id="options-api-rdfDirection-default" name="rdfDirection" value="" checked
+                    v-model="options.rdfDirection" @change="setOutputTab()">
+                  <label for="options-api-rdfDirection-default">Default (null)</label>
                 </div>
               </div>
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input
-                    type="radio"
-                    id="options-api-rdfDirection-i18n-datatype"
-                    name="rdfDirection"
-                    value="i18n-datatype"
-                    v-model="options.rdfDirection"
-                    @change="setOutputTab()"
-                  />
-                  <label for="options-api-rdfDirection-i18n-datatype"
-                    >"i18n-datatype"</label
-                  >
+                  <input type="radio" id="options-api-rdfDirection-i18n-datatype" name="rdfDirection" value="i18n-datatype"
+                    v-model="options.rdfDirection" @change="setOutputTab()">
+                  <label for="options-api-rdfDirection-i18n-datatype">"i18n-datatype"</label>
                 </div>
               </div>
             </div>
@@ -365,27 +232,15 @@ title: Next Playground
               <label for="options-api-safe" class="two wide field">Safe</label>
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input
-                    type="radio"
-                    id="options-api-safe-false"
-                    name="safe"
-                    :value="false"
-                    v-model="options.safe"
-                    @change="setOutputTab()"
-                  />
+                  <input type="radio" id="options-api-safe-false" name="safe" :value="false"
+                    v-model="options.safe" @change="setOutputTab()">
                   <label for="options-api-safe-false">False</label>
                 </div>
               </div>
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input
-                    type="radio"
-                    id="options-api-safe-true"
-                    name="safe"
-                    :value="true"
-                    v-model="options.safe"
-                    @change="setOutputTab()"
-                  />
+                  <input type="radio" id="options-api-safe-true" name="safe" :value="true"
+                    v-model="options.safe" @change="setOutputTab()">
                   <label for="options-api-safe-true">True</label>
                 </div>
               </div>
@@ -396,56 +251,32 @@ title: Next Playground
     </div>
     <div class="column" v-show="editorColumns != ''">
       <div class="ui top attached tabular menu">
-        <div
-          class="icon item"
-          v-show="outputTab == 'compacted' || outputTab == 'flattened'"
-        >
-          <i
-            class="arrow alternate circle down outline icon"
-            style="cursor: pointer"
-            title='Copy `@context` from "JSON-LD Input"'
-            @click="copyContext()"
-          ></i>
+        <div class="icon item" v-show="outputTab == 'compacted' || outputTab == 'flattened'">
+          <i class="arrow alternate circle down outline icon" style="cursor: pointer;"
+            title="Copy `@context` from &quot;JSON-LD Input&quot;"
+            @click="copyContext()"></i>
         </div>
-        <div class="active item">
-          <i class="pencil alternate icon"></i>
-          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'"
-            >New JSON-LD Context</span
-          >
+        <div class="active item"><i class="pencil alternate icon"></i>
+          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'">New JSON-LD Context</span>
           <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
         </div>
         <div class="right menu">
           <div class="item" style="padding-right: 0">
             <div class="ui icon input">
-              <input
-                type="text"
-                :placeholder="sideEditorURLFieldPlaceholderText"
-                v-model="remoteSideDocURL"
-                @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"
-              />
-              <i
-                class="file link icon"
-                @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"
-              ></i>
+              <input type="text" :placeholder="sideEditorURLFieldPlaceholderText"
+                v-model="remoteSideDocURL" @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)">
+              <i class="file link icon" @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"></i>
             </div>
           </div>
         </div>
       </div>
       <div class="ui bottom attached fitted resizable scrolling segment">
-        <div
-          id="context-editor"
+        <div id="context-editor"
           v-show="outputTab == 'compacted' || outputTab == 'flattened'"
-          @vue:mounted="initContextEditor()"
-        >
-          <!-- replaced by CodeMirror -->
-        </div>
-        <div
-          id="frame-editor"
+          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
+        <div id="frame-editor"
           v-show="outputTab == 'framed'"
-          @vue:mounted="initFrameEditor()"
-        >
-          <!-- replaced by CodeMirror -->
-        </div>
+          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
       </div>
     </div>
   </div>
@@ -458,26 +289,14 @@ title: Next Playground
   </div>
   <!-- outputs and renderings -->
   <div class="ui top attached tabular menu">
-    <div
-      v-for="(tab, key) in tabs"
-      :class="{ active: outputTab == key, disabled: doc === '' }"
-      class="item"
-      @click="setOutputTab(key)"
-    >
-      <i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span>
-    </div>
+    <div v-for="(tab, key) in tabs" :class="{ active: outputTab == key, disabled: doc === '' }" class="item" @click="setOutputTab(key)"><i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span></div>
   </div>
   <div class="ui fitted resizable active bottom attached tab segment">
     <div class="ui very compact divided grid">
       <div class="column" :class="{'eight wide': outputTab == 'cborld'}">
-        <div v-show="outputTab != 'table'" id="read-only-editor">
-          <!-- replaced by CodeMirror -->
-        </div>
-        <table
-          class="ui compact table"
-          style="margin-top: 0"
-          v-show="outputTab == 'table'"
-        >
+        <div v-show="outputTab != 'table'" id="read-only-editor"><!-- replaced by CodeMirror --></div>
+        <table class="ui compact table" style="margin-top: 0"
+          v-show="outputTab == 'table'">
           <thead>
             <tr>
               <th>Subject</th>
@@ -490,36 +309,28 @@ title: Next Playground
           </thead>
           <tr v-for="quad in tableQuads">
             <td>
-              <a
-                v-if="quad.subject.termType == 'NamedNode'"
+              <a v-if="quad.subject.termType == 'NamedNode'"
                 :href="quad.subject.value"
-                v-text="quad.subject.value"
-              ></a>
+                v-text="quad.subject.value"></a>
               <span v-else v-text="quad.subject.value"></span>
             </td>
             <td>
-              <a
-                v-if="quad.predicate.termType == 'NamedNode'"
+              <a v-if="quad.predicate.termType == 'NamedNode'"
                 :href="quad.predicate.value"
-                v-text="quad.predicate.value"
-              ></a>
+                v-text="quad.predicate.value"></a>
               <span v-else v-text="quad.predicate.value"></span>
             </td>
             <td>
-              <a
-                v-if="quad.object.termType == 'NamedNode'"
+              <a v-if="quad.object.termType == 'NamedNode'"
                 :href="quad.object.value"
-                v-text="quad.object.value"
-              ></a>
+                v-text="quad.object.value"></a>
               <span v-else v-text="quad.object.value"></span>
             </td>
             <td v-text="quad.object.language"></td>
             <td>
-              <a
-                v-if="quad.object.datatype"
-                :href="quad.object.datatype.value"
-                v-text="quad.object.datatype.value"
-              ></a>
+              <a v-if="quad.object.datatype"
+              :href="quad.object.datatype.value"
+                v-text="quad.object.datatype.value"></a>
             </td>
             <td v-text="quad.graph.value"></td>
           </tr>
@@ -528,20 +339,16 @@ title: Next Playground
       <div class="eight wide column" v-if="outputTab == 'cborld'">
         <table class="ui fixed definition table" style="margin-left: -0.25rem">
           <tr>
-            <td class="three wide">JSON-LD Size</td>
-            <td><span v-text="cborLD.jsonldSize"></span> bytes</td>
+            <td class="three wide">JSON-LD Size</td><td><span v-text="cborLD.jsonldSize"></span> bytes</td>
           </tr>
           <tr>
-            <td>CBOR-LD Size</td>
-            <td><span v-text="cborLD.size"></span> bytes</td>
+            <td>CBOR-LD Size</td><td><span v-text="cborLD.size"></span> bytes</td>
           </tr>
           <tr>
-            <td>Compression</td>
-            <td><span v-text="cborLD.percentage"></span>%</td>
+            <td>Compression</td><td><span v-text="cborLD.percentage"></span>%</td>
           </tr>
           <tr class="top aligned">
-            <td>Hex</td>
-            <td v-text="cborLD.hex" style="word-wrap: break-word"></td>
+            <td>Hex</td><td v-text="cborLD.hex" style="word-wrap: break-word;"></td>
           </tr>
         </table>
       </div>

--- a/playground/next/index.html
+++ b/playground/next/index.html
@@ -8,8 +8,11 @@ title: Next Playground
   <strong>NOTES</strong>:
   <ul>
     <li>
-      The playground uses <a href="https://github.com/digitalbazaar/jsonld.js">jsonld.js</a>
-      which <a href="https://github.com/digitalbazaar/jsonld.js#conformance">conforms</a>
+      The playground uses
+      <a href="https://github.com/digitalbazaar/jsonld.js">jsonld.js</a> which
+      <a href="https://github.com/digitalbazaar/jsonld.js#conformance"
+        >conforms</a
+      >
       to JSON-LD 1.1
       <a href="https://www.w3.org/TR/json-ld11/">syntax</a>
       (<a href="https://w3c.github.io/json-ld-syntax/errata/">errata</a>),
@@ -24,45 +27,73 @@ title: Next Playground
       <a href="https://vcplayground.org/">Verifiable Credentials Playground</a>
     </li>
   </ul>
-  <p>Accesibility note: use <code>Esc</code> and then <code>Tab</code> (or
-  <code>Shift+Tab</code>) to navigate out of the editor.</p>
+  <p>
+    Accesibility note: use <code>Esc</code> and then <code>Tab</code> (or
+    <code>Shift+Tab</code>) to navigate out of the editor.
+  </p>
 </div>
 
-<div class="ui wide container" v-scope v-effect="setOutputTab()" @vue:mounted="gatherHash()">
+<div
+  class="ui wide container"
+  v-scope
+  v-effect="setOutputTab()"
+  @vue:mounted="gatherHash()"
+>
   <div class="ui buttons">
     <button class="ui large basic right pointing label">Examples</button>
-    <button id="btn-person" class="ui button"
-      @click="loadExample('person.jsonld')">
+    <button
+      id="btn-person"
+      class="ui button"
+      @click="loadExample('person.jsonld')"
+    >
       <i class="icon user"></i>
       <span>Person</span>
     </button>
-    <button id="btn-event" class="ui button"
-      @click="loadExample('event.jsonld')">
+    <button
+      id="btn-event"
+      class="ui button"
+      @click="loadExample('event.jsonld')"
+    >
       <i class="icon calendar"></i>
       <span>Event</span>
     </button>
-    <button id="btn-place" class="ui button"
-      @click="loadExample('place.jsonld')">
+    <button
+      id="btn-place"
+      class="ui button"
+      @click="loadExample('place.jsonld')"
+    >
       <i class="icon map marker"></i>
       <span>Place</span>
     </button>
-    <button id="btn-product" class="ui button"
-      @click="loadExample('product.jsonld')">
+    <button
+      id="btn-product"
+      class="ui button"
+      @click="loadExample('product.jsonld')"
+    >
       <i class="icon barcode"></i>
       <span>Product</span>
     </button>
-    <button id="btn-recipe" class="ui button"
-      @click="loadExample('recipe.jsonld')">
+    <button
+      id="btn-recipe"
+      class="ui button"
+      @click="loadExample('recipe.jsonld')"
+    >
       <i class="icon food"></i>
       <span>Recipe</span>
     </button>
-    <button id="btn-library" class="ui button"
-      @click="loadExample('library.jsonld')">
+    <button
+      id="btn-library"
+      class="ui button"
+      @click="loadExample('library.jsonld')"
+    >
       <i class="icon book"></i>
       <span>Library</span>
     </button>
-    <button id="btn-activity" class="ui button"
-      @click="loadExample('activity.jsonld')">
+    <button
+      id="btn-activity"
+      class="ui button"
+      @click="loadExample('activity.jsonld')"
+    >
       <i class="icon comment"></i>
       <span>Activity</span>
     </button>
@@ -72,10 +103,15 @@ title: Next Playground
     <button id="permalink" class="ui icon button" data-position="left center">
       <i class="icon linkify"></i>
     </button>
-    <div class="ui popup" style="min-width: 20em;">
+    <div class="ui popup" style="min-width: 20em">
       <div class="ui top attached label">Share this</div>
       <div class="ui fluid action input">
-        <input type="text" readonly v-model="permalinkURL" @focus="$event.target.select()">
+        <input
+          type="text"
+          readonly
+          v-model="permalinkURL"
+          @focus="$event.target.select()"
+        />
         <button class="ui icon button" @click="copyPermalink()">
           <i class="icon copy"></i>
         </button>
@@ -84,7 +120,11 @@ title: Next Playground
         This link is longer than 2kb, and may not work.
       </div>
     </div>
-    <button id="keyboard-shortcuts" class="ui icon button" data-position="left center">
+    <button
+      id="keyboard-shortcuts"
+      class="ui icon button"
+      data-position="left center"
+    >
       <i class="icon keyboard"></i>
     </button>
     <div class="ui popup">
@@ -110,51 +150,128 @@ title: Next Playground
     </div>
   </div>
   <div class="ui icon message" v-if="message.text" :class="message.type">
-    <i class="icon" :class="{
+    <i
+      class="icon"
+      :class="{
       'info circle': message.type == 'info',
       'check circle': message.type == 'success',
       'times circle': message.type == 'error',
       'exclamation triangle': message.type == 'warning'
-    }"></i>
+    }"
+    ></i>
     <div class="content">
       <div class="header" v-text="message.text"></div>
     </div>
   </div>
   <!-- main editor area -->
-  <div class="ui one column wide compact grid container" :class="[editorColumns]">
+  <div
+    class="ui one column wide compact grid container"
+    :class="[editorColumns]"
+  >
     <div class="column" :class="{ 'sixteen wide':  editorColumns == '' }">
       <div class="ui top attached tabular menu">
-        <div :class="{ active: inputTab == 'json-ld' }" class="item" @click="inputTab = 'json-ld'"><i class="pencil alternate icon"></i> JSON-LD Input</div>
-        <div :class="{ active: inputTab == 'options' }" class="item" @click="inputTab = 'options'"><i class="wrench icon"></i> Options</div>
+        <div
+          :class="{ active: inputTab == 'json-ld' }"
+          class="item"
+          @click="inputTab = 'json-ld'"
+        >
+          <i class="pencil alternate icon"></i> JSON-LD Input
+        </div>
+        <div
+          :class="{ active: inputTab == 'options' }"
+          class="item"
+          @click="inputTab = 'options'"
+        >
+          <i class="wrench icon"></i> Options
+        </div>
         <div class="right menu">
           <div class="item" style="padding-right: 0">
             <div class="ui icon input">
-              <input type="text" placeholder="Document URL"
-                v-model="remoteDocURL" @keyup.enter="retrieveDoc(mainEditor, 'doc', remoteDocURL)">
-              <i class="file link icon" :class="{ disabled: remoteDocURL == '' }" @click="retrieveDoc(mainEditor, 'doc', remoteDocURL)"></i>
+              <input
+                type="text"
+                placeholder="Document URL"
+                v-model="remoteDocURL"
+                @keyup.enter="retrieveDoc(mainEditor, 'doc', remoteDocURL)"
+              />
+              <i
+                class="file link icon"
+                :class="{ disabled: remoteDocURL == '' }"
+                @click="retrieveDoc(mainEditor, 'doc', remoteDocURL)"
+              ></i>
             </div>
           </div>
         </div>
       </div>
-      <div class="ui bottom attached fitted resizable scrolling segment" v-show="inputTab == 'json-ld'">
-        <div id="editor" @vue:mounted="initMainEditor()"><!-- replaced by CodeMirror --></div>
+      <div
+        class="ui bottom attached fitted resizable scrolling segment"
+        v-show="inputTab == 'json-ld'"
+      >
+        <div id="editor" @vue:mounted="initMainEditor()">
+          <!-- replaced by CodeMirror -->
+        </div>
       </div>
       <div class="ui bottom attached segment" v-show="inputTab == 'options'">
         <form class="ui form">
           <div class="inline fields" id="options-api-processingMode">
-            <label for="options-api-processingMode" class="two wide field">Processing Mode</label>
+            <label for="options-api-processingMode" class="two wide field"
+              >Processing Mode</label
+            >
             <div class="field">
               <div class="ui radio checkbox">
-                <input type="radio" id="options-api-processingMode-1-0" name="processingMode" value="json-ld-1.0"
-                  v-model="options.processingMode" @change="setOutputTab()">
+                <input
+                  type="radio"
+                  id="options-api-processingMode-1-0"
+                  name="processingMode"
+                  value="json-ld-1.0"
+                  v-model="options.processingMode"
+                  @change="setOutputTab()"
+                />
                 <label for="options-api-processingMode-1-0">JSON-LD 1.0</label>
               </div>
             </div>
             <div class="field">
               <div class="ui radio checkbox">
-                <input type="radio" id="options-api-processingMode-1-1" name="processingMode" value="json-ld-1.1"
-                  v-model="options.processingMode" @change="setOutputTab()">
+                <input
+                  type="radio"
+                  id="options-api-processingMode-1-1"
+                  name="processingMode"
+                  value="json-ld-1.1"
+                  v-model="options.processingMode"
+                  @change="setOutputTab()"
+                />
                 <label for="options-api-processingMode-1-1">JSON-LD 1.1</label>
+              </div>
+            </div>
+          </div>
+
+          <div class="inline fields" id="options-formatMode">
+            <label for="options-formatMode" class="two wide field"
+              >Format</label
+            >
+            <div class="field">
+              <div class="ui radio checkbox">
+                <input
+                  type="radio"
+                  id="options-formatMode-json"
+                  name="formatMode"
+                  value="json"
+                  v-model="options.formatMode"
+                  @change="setOutputTab()"
+                />
+                <label for="options-formatMode-json">JSON</label>
+              </div>
+            </div>
+            <div class="field">
+              <div class="ui radio checkbox">
+                <input
+                  type="radio"
+                  id="options-formatMode-yaml"
+                  name="formatMode"
+                  value="yaml"
+                  v-model="options.formatMode"
+                  @change="setOutputTab()"
+                />
+                <label for="options-formatMode-yaml">YAML</label>
               </div>
             </div>
           </div>
@@ -162,8 +279,13 @@ title: Next Playground
           <div class="inline fields" id="options-api-base">
             <label for="options-api-base" class="two wide field">Base</label>
             <div class="sixteen wide field">
-              <input type="text" id="options-api-base-url" placeholder="URL"
-                v-model="options.base" @change="setOutputTab()">
+              <input
+                type="text"
+                id="options-api-base-url"
+                placeholder="URL"
+                v-model="options.base"
+                @change="setOutputTab()"
+              />
             </div>
           </div>
 
@@ -171,8 +293,12 @@ title: Next Playground
             <label class="two wide field"></label>
             <div class="field">
               <div class="ui checkbox">
-                <input type="checkbox" id="options-api-compactArrays"
-                  v-model="options.compactArrays" @change="setOutputTab()">
+                <input
+                  type="checkbox"
+                  id="options-api-compactArrays"
+                  v-model="options.compactArrays"
+                  @change="setOutputTab()"
+                />
                 <label for="options-api-compactArrays">Compact Arrays</label>
               </div>
             </div>
@@ -182,28 +308,53 @@ title: Next Playground
             <label class="two wide field"></label>
             <div class="field">
               <div class="ui checkbox">
-                <input type="checkbox" id="options-api-compactToRelative"
-                  v-model="options.compactToRelative" @change="setOutputTab()">
-                <label for="options-api-compactToRelative">Compact To Relative</label>
+                <input
+                  type="checkbox"
+                  id="options-api-compactToRelative"
+                  v-model="options.compactToRelative"
+                  @change="setOutputTab()"
+                />
+                <label for="options-api-compactToRelative"
+                  >Compact To Relative</label
+                >
               </div>
             </div>
           </div>
 
           <div class="field">
             <div class="inline fields" id="options-api-rdfDirection">
-              <label for="options-api-rdfDirection" class="two wide field">RDF Direction Mode</label>
+              <label for="options-api-rdfDirection" class="two wide field"
+                >RDF Direction Mode</label
+              >
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input type="radio" id="options-api-rdfDirection-default" name="rdfDirection" value="" checked
-                    v-model="options.rdfDirection" @change="setOutputTab()">
-                  <label for="options-api-rdfDirection-default">Default (null)</label>
+                  <input
+                    type="radio"
+                    id="options-api-rdfDirection-default"
+                    name="rdfDirection"
+                    value=""
+                    checked
+                    v-model="options.rdfDirection"
+                    @change="setOutputTab()"
+                  />
+                  <label for="options-api-rdfDirection-default"
+                    >Default (null)</label
+                  >
                 </div>
               </div>
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input type="radio" id="options-api-rdfDirection-i18n-datatype" name="rdfDirection" value="i18n-datatype"
-                    v-model="options.rdfDirection" @change="setOutputTab()">
-                  <label for="options-api-rdfDirection-i18n-datatype">"i18n-datatype"</label>
+                  <input
+                    type="radio"
+                    id="options-api-rdfDirection-i18n-datatype"
+                    name="rdfDirection"
+                    value="i18n-datatype"
+                    v-model="options.rdfDirection"
+                    @change="setOutputTab()"
+                  />
+                  <label for="options-api-rdfDirection-i18n-datatype"
+                    >"i18n-datatype"</label
+                  >
                 </div>
               </div>
             </div>
@@ -214,15 +365,27 @@ title: Next Playground
               <label for="options-api-safe" class="two wide field">Safe</label>
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input type="radio" id="options-api-safe-false" name="safe" :value="false"
-                    v-model="options.safe" @change="setOutputTab()">
+                  <input
+                    type="radio"
+                    id="options-api-safe-false"
+                    name="safe"
+                    :value="false"
+                    v-model="options.safe"
+                    @change="setOutputTab()"
+                  />
                   <label for="options-api-safe-false">False</label>
                 </div>
               </div>
               <div class="field">
                 <div class="ui radio checkbox">
-                  <input type="radio" id="options-api-safe-true" name="safe" :value="true"
-                    v-model="options.safe" @change="setOutputTab()">
+                  <input
+                    type="radio"
+                    id="options-api-safe-true"
+                    name="safe"
+                    :value="true"
+                    v-model="options.safe"
+                    @change="setOutputTab()"
+                  />
                   <label for="options-api-safe-true">True</label>
                 </div>
               </div>
@@ -233,32 +396,56 @@ title: Next Playground
     </div>
     <div class="column" v-show="editorColumns != ''">
       <div class="ui top attached tabular menu">
-        <div class="icon item" v-show="outputTab == 'compacted' || outputTab == 'flattened'">
-          <i class="arrow alternate circle down outline icon" style="cursor: pointer;"
-            title="Copy `@context` from &quot;JSON-LD Input&quot;"
-            @click="copyContext()"></i>
+        <div
+          class="icon item"
+          v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+        >
+          <i
+            class="arrow alternate circle down outline icon"
+            style="cursor: pointer"
+            title='Copy `@context` from "JSON-LD Input"'
+            @click="copyContext()"
+          ></i>
         </div>
-        <div class="active item"><i class="pencil alternate icon"></i>
-          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'">New JSON-LD Context</span>
+        <div class="active item">
+          <i class="pencil alternate icon"></i>
+          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+            >New JSON-LD Context</span
+          >
           <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
         </div>
         <div class="right menu">
           <div class="item" style="padding-right: 0">
             <div class="ui icon input">
-              <input type="text" :placeholder="sideEditorURLFieldPlaceholderText"
-                v-model="remoteSideDocURL" @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)">
-              <i class="file link icon" @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"></i>
+              <input
+                type="text"
+                :placeholder="sideEditorURLFieldPlaceholderText"
+                v-model="remoteSideDocURL"
+                @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"
+              />
+              <i
+                class="file link icon"
+                @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"
+              ></i>
             </div>
           </div>
         </div>
       </div>
       <div class="ui bottom attached fitted resizable scrolling segment">
-        <div id="context-editor"
+        <div
+          id="context-editor"
           v-show="outputTab == 'compacted' || outputTab == 'flattened'"
-          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
-        <div id="frame-editor"
+          @vue:mounted="initContextEditor()"
+        >
+          <!-- replaced by CodeMirror -->
+        </div>
+        <div
+          id="frame-editor"
           v-show="outputTab == 'framed'"
-          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
+          @vue:mounted="initFrameEditor()"
+        >
+          <!-- replaced by CodeMirror -->
+        </div>
       </div>
     </div>
   </div>
@@ -271,14 +458,26 @@ title: Next Playground
   </div>
   <!-- outputs and renderings -->
   <div class="ui top attached tabular menu">
-    <div v-for="(tab, key) in tabs" :class="{ active: outputTab == key, disabled: doc === '' }" class="item" @click="setOutputTab(key)"><i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span></div>
+    <div
+      v-for="(tab, key) in tabs"
+      :class="{ active: outputTab == key, disabled: doc === '' }"
+      class="item"
+      @click="setOutputTab(key)"
+    >
+      <i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span>
+    </div>
   </div>
   <div class="ui fitted resizable active bottom attached tab segment">
     <div class="ui very compact divided grid">
       <div class="column" :class="{'eight wide': outputTab == 'cborld'}">
-        <div v-show="outputTab != 'table'" id="read-only-editor"><!-- replaced by CodeMirror --></div>
-        <table class="ui compact table" style="margin-top: 0"
-          v-show="outputTab == 'table'">
+        <div v-show="outputTab != 'table'" id="read-only-editor">
+          <!-- replaced by CodeMirror -->
+        </div>
+        <table
+          class="ui compact table"
+          style="margin-top: 0"
+          v-show="outputTab == 'table'"
+        >
           <thead>
             <tr>
               <th>Subject</th>
@@ -291,28 +490,36 @@ title: Next Playground
           </thead>
           <tr v-for="quad in tableQuads">
             <td>
-              <a v-if="quad.subject.termType == 'NamedNode'"
+              <a
+                v-if="quad.subject.termType == 'NamedNode'"
                 :href="quad.subject.value"
-                v-text="quad.subject.value"></a>
+                v-text="quad.subject.value"
+              ></a>
               <span v-else v-text="quad.subject.value"></span>
             </td>
             <td>
-              <a v-if="quad.predicate.termType == 'NamedNode'"
+              <a
+                v-if="quad.predicate.termType == 'NamedNode'"
                 :href="quad.predicate.value"
-                v-text="quad.predicate.value"></a>
+                v-text="quad.predicate.value"
+              ></a>
               <span v-else v-text="quad.predicate.value"></span>
             </td>
             <td>
-              <a v-if="quad.object.termType == 'NamedNode'"
+              <a
+                v-if="quad.object.termType == 'NamedNode'"
                 :href="quad.object.value"
-                v-text="quad.object.value"></a>
+                v-text="quad.object.value"
+              ></a>
               <span v-else v-text="quad.object.value"></span>
             </td>
             <td v-text="quad.object.language"></td>
             <td>
-              <a v-if="quad.object.datatype"
-              :href="quad.object.datatype.value"
-                v-text="quad.object.datatype.value"></a>
+              <a
+                v-if="quad.object.datatype"
+                :href="quad.object.datatype.value"
+                v-text="quad.object.datatype.value"
+              ></a>
             </td>
             <td v-text="quad.graph.value"></td>
           </tr>
@@ -321,16 +528,20 @@ title: Next Playground
       <div class="eight wide column" v-if="outputTab == 'cborld'">
         <table class="ui fixed definition table" style="margin-left: -0.25rem">
           <tr>
-            <td class="three wide">JSON-LD Size</td><td><span v-text="cborLD.jsonldSize"></span> bytes</td>
+            <td class="three wide">JSON-LD Size</td>
+            <td><span v-text="cborLD.jsonldSize"></span> bytes</td>
           </tr>
           <tr>
-            <td>CBOR-LD Size</td><td><span v-text="cborLD.size"></span> bytes</td>
+            <td>CBOR-LD Size</td>
+            <td><span v-text="cborLD.size"></span> bytes</td>
           </tr>
           <tr>
-            <td>Compression</td><td><span v-text="cborLD.percentage"></span>%</td>
+            <td>Compression</td>
+            <td><span v-text="cborLD.percentage"></span>%</td>
           </tr>
           <tr class="top aligned">
-            <td>Hex</td><td v-text="cborLD.hex" style="word-wrap: break-word;"></td>
+            <td>Hex</td>
+            <td v-text="cborLD.hex" style="word-wrap: break-word"></td>
           </tr>
         </table>
       </div>

--- a/playground/next/index.html
+++ b/playground/next/index.html
@@ -165,7 +165,7 @@ title: Next Playground
               <div class="ui radio checkbox">
                 <input type="radio" id="options-formatMode-json" name="formatMode" value="json"
                   v-model="options.formatMode" @change="setOutputTab()">
-                <label for="options-api-processingMode-1-0">JSON</label>
+                <label for="options-formatMode-json">JSON</label>
               </div>
             </div>
             <div class="field">


### PR DESCRIPTION
Add selectable JSON/YAML format in Options tab

This PR introduces the ability to choose the preferred output format (JSON or YAML) directly from the Options tab.
The selected format is applied immediately to the generated output and is persisted during the session.

<img width="666" height="402" alt="Schermata del 2026-02-20 17-54-32" src="https://github.com/user-attachments/assets/76851d28-449b-4005-b220-64e744b51806" />

 Data structure is also validated.
<img width="1061" height="755" alt="Schermata del 2026-02-20 17-58-57" src="https://github.com/user-attachments/assets/131e2cc3-733c-4dc5-8918-53ef86f8ae46" />
<img width="1061" height="755" alt="Schermata del 2026-02-20 17-59-54" src="https://github.com/user-attachments/assets/203e0998-3db8-4d7c-be3f-04216930357a" />

