### PR TITLE
Fix:#7. Moved output panel to the right of JSON-LD input.

### DIFF
--- a/playground/next/index.html
+++ b/playground/next/index.html
@@ -122,7 +122,7 @@ title: Next Playground
   </div>
   <!-- main editor area -->
   <div class="ui one column wide compact grid container" :class="[editorColumns]">
-    <div class="ui top attached tabular menu tabs-menu">
+    <div class="ui top attached tabular menu tabs-menu" style="margin-top: 10px;">
       <div
         v-for="(tab, key) in tabs"
         :class="{ active: outputTab == key, disabled: doc === '' }"
@@ -132,9 +132,9 @@ title: Next Playground
         <i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span>
       </div>
     </div>
-    <div style="width: 100%;">
+    <div :class="editorColumns == '' ? 'row' : 'eight wide column'">
       <div
-        class="ui top attached tabular menu" :style="{ width: editorColumns == '' ? '100%' : '50%' }"
+        class="ui top attached tabular menu"
       >
         <div :class="{ active: inputTab == 'json-ld' }" class="item" @click="inputTab = 'json-ld'"><i class="pencil alternate icon"></i> JSON-LD Input</div>
         <div :class="{ active: inputTab == 'options' }" class="item" @click="inputTab = 'options'"><i class="wrench icon"></i> Options</div>
@@ -147,11 +147,6 @@ title: Next Playground
             </div>
           </div>
         </div></div>
-    </div>
-    <div
-      class="eight wide column"
-      :class="{ 'sixteen wide': editorColumns == '' }"
-    >
       <div
         class="ui bottom attached fitted resizable scrolling segment"
         v-show="inputTab == 'json-ld'"
@@ -269,6 +264,13 @@ title: Next Playground
           </div>
         </form>
       </div>
+      <!-- errors -->
+      <div class="ui error message row" v-show="parseError.message" style="width: 100%;">
+        <div class="header" v-text="parseError.message"></div>
+        <div class="content">
+        <pre v-text="JSON.stringify(parseError?.details?.event, null, 2)"></pre>
+        </div>
+      </div>
       <!-- outputs and renderings -->
       <div class="ui grid">
   <div class="column" v-show="editorColumns != ''">
@@ -303,10 +305,10 @@ title: Next Playground
         </div>
       </div>
     </div>
-    <div class="eight wide column">
+    <div :style="{ width: editorColumns == '' ? '100%' : '50%', paddingTop: editorColumns == '' ? '10px' : '59px'}">
       <div
         class="ui fitted resizable active bottom attached tab segment"
-       :style="{ marginTop: editorColumns ? '0' : '10px', height: '100%' }"
+       :style="{ marginTop: editorColumns ? '0' : '10px', height: '100%' }" 
       >
         <div class="ui very compact divided grid">
           <div class="column" :class="{'eight wide': outputTab == 'cborld'}">
@@ -370,14 +372,8 @@ title: Next Playground
           </div>
         </div>
       </div>
-  </div>
-  <!-- errors -->
-  <div class="ui error message" v-show="parseError.message">
-    <div class="header" v-text="parseError.message"></div>
-    <div class="content">
-      <pre v-text="JSON.stringify(parseError?.details?.event, null, 2)"></pre>
     </div>
-  </div>
+    </div>
 </div>
 </div>
 

--- a/playground/next/index.html
+++ b/playground/next/index.html
@@ -123,7 +123,7 @@ title: Next Playground
   <div class="ui one column wide compact grid container" :class="[editorColumns]">
     <div class="column" :class="{ 'sixteen wide':  editorColumns == '' }">
       <div class="ui top attached tabular menu">
-        <div :class="{ active: inputTab == 'json-ld' }" class="item" @click="inputTab = 'json-ld'" v-text="inputLabel"><i class="pencil alternate icon"></i></div>
+        <div :class="{ active: inputTab == 'json-ld' }" class="item" @click="inputTab = 'json-ld'"><i class="pencil alternate icon"></i> JSON-LD Input</div>
         <div :class="{ active: inputTab == 'options' }" class="item" @click="inputTab = 'options'"><i class="wrench icon"></i> Options</div>
         <div class="right menu">
           <div class="item" style="padding-right: 0">
@@ -134,11 +134,12 @@ title: Next Playground
             </div>
           </div>
         </div>
-      </div>
+      </div></div>
+    <div class="eight wide column" :class="{ 'sixteen wide':  editorColumns == '' }">
       <div class="ui bottom attached fitted resizable scrolling segment" v-show="inputTab == 'json-ld'">
         <div id="editor" @vue:mounted="initMainEditor()"><!-- replaced by CodeMirror --></div>
       </div>
-      <div class="ui bottom attached segment" v-show="inputTab == 'options'">
+      <div class="ui bottom attached segment" v-show="inputTab == 'options'"  >
         <form class="ui form">
           <div class="inline fields" id="options-api-processingMode">
             <label for="options-api-processingMode" class="two wide field">Processing Mode</label>
@@ -247,12 +248,42 @@ title: Next Playground
           </div>
         </form>
       </div>
+  <!-- outputs and renderings -->
+  <div class="ui grid">
+  <div class="column" v-show="editorColumns != ''">
+      <div class="ui top attached tabular menu">
+        <div class="icon item" v-show="outputTab == 'compacted' || outputTab == 'flattened'">
+          <i class="arrow alternate circle down outline icon" style="cursor: pointer;"
+            title="Copy `@context` from &quot;JSON-LD Input&quot;"
+            @click="copyContext()"></i>
+        </div>
+        <div class="active item"><i class="pencil alternate icon"></i>
+          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'">New JSON-LD Context</span>
+          <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
+        </div>
+        <div class="right menu">
+          <div class="item" style="padding-right: 0">
+            <div class="ui icon input">
+              <input type="text" :placeholder="sideEditorURLFieldPlaceholderText"
+                v-model="remoteSideDocURL" @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)">
+              <i class="file link icon" @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="ui bottom attached fitted resizable scrolling segment">
+        <div id="context-editor"
+          v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
+        <div id="frame-editor"
+          v-show="outputTab == 'framed'"
+          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
+      </div>
     </div>
-     <div class="ui top attached tabular menu tabs-menu"  v-show="editorColumns == ''" >
-    <div v-for="(tab, key) in tabs" :class="{ active: outputTab == key, disabled: doc === '' }" class="item" @click="setOutputTab(key)"><i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span></div>
-  </div>
-  <div  class="column">
-  <div class="ui fitted resizable active bottom attached tab segment">
+</div>
+    </div>
+  <div  class="eight wide column">
+  <div class="ui fitted resizable active bottom attached tab segment" :style="{ marginTop: editorColumns == '' ? '10px' : '0px', height: '100%' }">
     <div class="ui very compact divided grid">
       <div class="column" :class="{'eight wide': outputTab == 'cborld'}">
         <div v-show="outputTab != 'table'"  style="min-height: 200px;" id="read-only-editor"><!-- replaced by CodeMirror --></div>
@@ -314,7 +345,7 @@ title: Next Playground
         </table>
       </div>
     </div>
-  </div></div>
+  </div>
   </div>
   <!-- errors -->
   <div class="ui error message" v-show="parseError.message">
@@ -323,41 +354,7 @@ title: Next Playground
       <pre v-text="JSON.stringify(parseError?.details?.event, null, 2)"></pre>
     </div>
   </div>
-  <!-- outputs and renderings -->
- <div class="ui top attached tabular menu tabs-menu" v-show="editorColumns != ''">
-    <div v-for="(tab, key) in tabs" :class="{ active: outputTab == key, disabled: doc === '' }" class="item" @click="setOutputTab(key)"><i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span></div>
-  </div>
-  <div class="ui grid">
-  <div class="eight wide column" v-show="editorColumns != ''">
-      <div class="ui top attached tabular menu">
-        <div class="icon item" v-show="outputTab == 'compacted' || outputTab == 'flattened'">
-          <i class="arrow alternate circle down outline icon" style="cursor: pointer;"
-            title="Copy `@context` from &quot;JSON-LD Input&quot;"
-            @click="copyContext()"></i>
-        </div>
-        <div class="active item"><i class="pencil alternate icon"></i>
-          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'">New JSON-LD Context</span>
-          <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
-        </div>
-        <div class="right menu">
-          <div class="item" style="padding-right: 0">
-            <div class="ui icon input">
-              <input type="text" :placeholder="sideEditorURLFieldPlaceholderText"
-                v-model="remoteSideDocURL" @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)">
-              <i class="file link icon" @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"></i>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="ui bottom attached fitted resizable scrolling segment">
-        <div id="context-editor"
-          v-show="outputTab == 'compacted' || outputTab == 'flattened'"
-          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
-        <div id="frame-editor"
-          v-show="outputTab == 'framed'"
-          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
-      </div>
-    </div></div>
+</div>
 </div>
 
 <script src="./editor.bundle.js"></script>

--- a/playground/next/index.html
+++ b/playground/next/index.html
@@ -2,7 +2,6 @@
 layout: fomantic
 title: Next Playground
 ---
-
 <h2 class="ui massive header">JSON-LD Playground</h2>
 <div class="ui info message">
   <strong>NOTES</strong>:
@@ -249,52 +248,14 @@ title: Next Playground
         </form>
       </div>
     </div>
-    <div class="column" v-show="editorColumns != ''">
-      <div class="ui top attached tabular menu">
-        <div class="icon item" v-show="outputTab == 'compacted' || outputTab == 'flattened'">
-          <i class="arrow alternate circle down outline icon" style="cursor: pointer;"
-            title="Copy `@context` from &quot;JSON-LD Input&quot;"
-            @click="copyContext()"></i>
-        </div>
-        <div class="active item"><i class="pencil alternate icon"></i>
-          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'">New JSON-LD Context</span>
-          <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
-        </div>
-        <div class="right menu">
-          <div class="item" style="padding-right: 0">
-            <div class="ui icon input">
-              <input type="text" :placeholder="sideEditorURLFieldPlaceholderText"
-                v-model="remoteSideDocURL" @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)">
-              <i class="file link icon" @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"></i>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="ui bottom attached fitted resizable scrolling segment">
-        <div id="context-editor"
-          v-show="outputTab == 'compacted' || outputTab == 'flattened'"
-          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
-        <div id="frame-editor"
-          v-show="outputTab == 'framed'"
-          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
-      </div>
-    </div>
-  </div>
-  <!-- errors -->
-  <div class="ui error message" v-show="parseError.message">
-    <div class="header" v-text="parseError.message"></div>
-    <div class="content">
-      <pre v-text="JSON.stringify(parseError?.details?.event, null, 2)"></pre>
-    </div>
-  </div>
-  <!-- outputs and renderings -->
-  <div class="ui top attached tabular menu">
+     <div class="ui top attached tabular menu tabs-menu"  v-show="editorColumns == ''" >
     <div v-for="(tab, key) in tabs" :class="{ active: outputTab == key, disabled: doc === '' }" class="item" @click="setOutputTab(key)"><i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span></div>
   </div>
+  <div  class="column">
   <div class="ui fitted resizable active bottom attached tab segment">
     <div class="ui very compact divided grid">
       <div class="column" :class="{'eight wide': outputTab == 'cborld'}">
-        <div v-show="outputTab != 'table'" id="read-only-editor"><!-- replaced by CodeMirror --></div>
+        <div v-show="outputTab != 'table'"  style="min-height: 200px;" id="read-only-editor"><!-- replaced by CodeMirror --></div>
         <table class="ui compact table" style="margin-top: 0"
           v-show="outputTab == 'table'">
           <thead>
@@ -353,7 +314,50 @@ title: Next Playground
         </table>
       </div>
     </div>
+  </div></div>
   </div>
+  <!-- errors -->
+  <div class="ui error message" v-show="parseError.message">
+    <div class="header" v-text="parseError.message"></div>
+    <div class="content">
+      <pre v-text="JSON.stringify(parseError?.details?.event, null, 2)"></pre>
+    </div>
+  </div>
+  <!-- outputs and renderings -->
+ <div class="ui top attached tabular menu tabs-menu" v-show="editorColumns != ''">
+    <div v-for="(tab, key) in tabs" :class="{ active: outputTab == key, disabled: doc === '' }" class="item" @click="setOutputTab(key)"><i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span></div>
+  </div>
+  <div class="ui grid">
+  <div class="eight wide column" v-show="editorColumns != ''">
+      <div class="ui top attached tabular menu">
+        <div class="icon item" v-show="outputTab == 'compacted' || outputTab == 'flattened'">
+          <i class="arrow alternate circle down outline icon" style="cursor: pointer;"
+            title="Copy `@context` from &quot;JSON-LD Input&quot;"
+            @click="copyContext()"></i>
+        </div>
+        <div class="active item"><i class="pencil alternate icon"></i>
+          <span v-show="outputTab == 'compacted' || outputTab == 'flattened'">New JSON-LD Context</span>
+          <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
+        </div>
+        <div class="right menu">
+          <div class="item" style="padding-right: 0">
+            <div class="ui icon input">
+              <input type="text" :placeholder="sideEditorURLFieldPlaceholderText"
+                v-model="remoteSideDocURL" @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)">
+              <i class="file link icon" @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"></i>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="ui bottom attached fitted resizable scrolling segment">
+        <div id="context-editor"
+          v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
+        <div id="frame-editor"
+          v-show="outputTab == 'framed'"
+          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
+      </div>
+    </div></div>
 </div>
 
 <script src="./editor.bundle.js"></script>

--- a/playground/next/index.html
+++ b/playground/next/index.html
@@ -2,6 +2,7 @@
 layout: fomantic
 title: Next Playground
 ---
+
 <h2 class="ui massive header">JSON-LD Playground</h2>
 <div class="ui info message">
   <strong>NOTES</strong>:
@@ -121,8 +122,20 @@ title: Next Playground
   </div>
   <!-- main editor area -->
   <div class="ui one column wide compact grid container" :class="[editorColumns]">
-    <div class="column" :class="{ 'sixteen wide':  editorColumns == '' }">
-      <div class="ui top attached tabular menu">
+    <div class="ui top attached tabular menu tabs-menu">
+      <div
+        v-for="(tab, key) in tabs"
+        :class="{ active: outputTab == key, disabled: doc === '' }"
+        class="item"
+        @click="setOutputTab(key)"
+      >
+        <i class="icon" :class="tab.icon"></i> <span v-text="tab.label"></span>
+      </div>
+    </div>
+    <div style="width: 100%;">
+      <div
+        class="ui top attached tabular menu" :style="{ width: editorColumns == '' ? '100%' : '50%' }"
+      >
         <div :class="{ active: inputTab == 'json-ld' }" class="item" @click="inputTab = 'json-ld'"><i class="pencil alternate icon"></i> JSON-LD Input</div>
         <div :class="{ active: inputTab == 'options' }" class="item" @click="inputTab = 'options'"><i class="wrench icon"></i> Options</div>
         <div class="right menu">
@@ -133,11 +146,19 @@ title: Next Playground
               <i class="file link icon" :class="{ disabled: remoteDocURL == '' }" @click="retrieveDoc(mainEditor, 'doc', remoteDocURL)"></i>
             </div>
           </div>
+        </div></div>
+    </div>
+    <div
+      class="eight wide column"
+      :class="{ 'sixteen wide': editorColumns == '' }"
+    >
+      <div
+        class="ui bottom attached fitted resizable scrolling segment"
+        v-show="inputTab == 'json-ld'"
+      >
+        <div id="editor" @vue:mounted="initMainEditor()">
+          <!-- replaced by CodeMirror -->
         </div>
-      </div></div>
-    <div class="eight wide column" :class="{ 'sixteen wide':  editorColumns == '' }">
-      <div class="ui bottom attached fitted resizable scrolling segment" v-show="inputTab == 'json-ld'">
-        <div id="editor" @vue:mounted="initMainEditor()"><!-- replaced by CodeMirror --></div>
       </div>
       <div class="ui bottom attached segment" v-show="inputTab == 'options'"  >
         <form class="ui form">
@@ -248,104 +269,107 @@ title: Next Playground
           </div>
         </form>
       </div>
-  <!-- outputs and renderings -->
-  <div class="ui grid">
+      <!-- outputs and renderings -->
+      <div class="ui grid">
   <div class="column" v-show="editorColumns != ''">
-      <div class="ui top attached tabular menu">
+          <div class="ui top attached tabular menu">
         <div class="icon item" v-show="outputTab == 'compacted' || outputTab == 'flattened'">
           <i class="arrow alternate circle down outline icon" style="cursor: pointer;"
             title="Copy `@context` from &quot;JSON-LD Input&quot;"
             @click="copyContext()"></i>
-        </div>
+            </div>
         <div class="active item"><i class="pencil alternate icon"></i>
           <span v-show="outputTab == 'compacted' || outputTab == 'flattened'">New JSON-LD Context</span>
-          <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
-        </div>
-        <div class="right menu">
-          <div class="item" style="padding-right: 0">
-            <div class="ui icon input">
+              <span v-show="outputTab == 'framed'">JSON-LD Frame</span>
+            </div>
+            <div class="right menu">
+              <div class="item" style="padding-right: 0">
+                <div class="ui icon input">
               <input type="text" :placeholder="sideEditorURLFieldPlaceholderText"
                 v-model="remoteSideDocURL" @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)">
               <i class="file link icon" @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"></i>
+                </div>
+              </div>
             </div>
+          </div>
+          <div class="ui bottom attached fitted resizable scrolling segment">
+        <div id="context-editor"
+              v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
+        <div id="frame-editor"
+              v-show="outputTab == 'framed'"
+          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
           </div>
         </div>
       </div>
-      <div class="ui bottom attached fitted resizable scrolling segment">
-        <div id="context-editor"
-          v-show="outputTab == 'compacted' || outputTab == 'flattened'"
-          @vue:mounted="initContextEditor()"><!-- replaced by CodeMirror --></div>
-        <div id="frame-editor"
-          v-show="outputTab == 'framed'"
-          @vue:mounted="initFrameEditor()"><!-- replaced by CodeMirror --></div>
-      </div>
     </div>
-</div>
-    </div>
-  <div  class="eight wide column">
-  <div class="ui fitted resizable active bottom attached tab segment" :style="{ marginTop: editorColumns == '' ? '10px' : '0px', height: '100%' }">
-    <div class="ui very compact divided grid">
-      <div class="column" :class="{'eight wide': outputTab == 'cborld'}">
+    <div class="eight wide column">
+      <div
+        class="ui fitted resizable active bottom attached tab segment"
+       :style="{ marginTop: editorColumns ? '0' : '10px', height: '100%' }"
+      >
+        <div class="ui very compact divided grid">
+          <div class="column" :class="{'eight wide': outputTab == 'cborld'}">
         <div v-show="outputTab != 'table'"  style="min-height: 200px;" id="read-only-editor"><!-- replaced by CodeMirror --></div>
         <table class="ui compact table" style="margin-top: 0"
           v-show="outputTab == 'table'">
-          <thead>
-            <tr>
-              <th>Subject</th>
-              <th>Predicate</th>
-              <th>Object</th>
-              <th>Language</th>
-              <th>Datatype</th>
-              <th>Graph</th>
-            </tr>
-          </thead>
-          <tr v-for="quad in tableQuads">
-            <td>
+              <thead>
+                <tr>
+                  <th>Subject</th>
+                  <th>Predicate</th>
+                  <th>Object</th>
+                  <th>Language</th>
+                  <th>Datatype</th>
+                  <th>Graph</th>
+                </tr>
+              </thead>
+              <tr v-for="quad in tableQuads">
+                <td>
               <a v-if="quad.subject.termType == 'NamedNode'"
-                :href="quad.subject.value"
+                    :href="quad.subject.value"
                 v-text="quad.subject.value"></a>
-              <span v-else v-text="quad.subject.value"></span>
-            </td>
-            <td>
+                  <span v-else v-text="quad.subject.value"></span>
+                </td>
+                <td>
               <a v-if="quad.predicate.termType == 'NamedNode'"
-                :href="quad.predicate.value"
+                    :href="quad.predicate.value"
                 v-text="quad.predicate.value"></a>
-              <span v-else v-text="quad.predicate.value"></span>
-            </td>
-            <td>
+                  <span v-else v-text="quad.predicate.value"></span>
+                </td>
+                <td>
               <a v-if="quad.object.termType == 'NamedNode'"
-                :href="quad.object.value"
+                    :href="quad.object.value"
                 v-text="quad.object.value"></a>
-              <span v-else v-text="quad.object.value"></span>
-            </td>
-            <td v-text="quad.object.language"></td>
-            <td>
+                  <span v-else v-text="quad.object.value"></span>
+                </td>
+                <td v-text="quad.object.language"></td>
+                <td>
               <a v-if="quad.object.datatype"
-              :href="quad.object.datatype.value"
+                    :href="quad.object.datatype.value"
                 v-text="quad.object.datatype.value"></a>
-            </td>
-            <td v-text="quad.graph.value"></td>
-          </tr>
-        </table>
-      </div>
-      <div class="eight wide column" v-if="outputTab == 'cborld'">
+                </td>
+                <td v-text="quad.graph.value"></td>
+              </tr>
+            </table>
+          </div>
+          <div class="eight wide column" v-if="outputTab == 'cborld'">
         <table class="ui fixed definition table" style="margin-left: -0.25rem">
-          <tr>
+              <tr>
             <td class="three wide">JSON-LD Size</td><td><span v-text="cborLD.jsonldSize"></span> bytes</td>
-          </tr>
-          <tr>
+              </tr>
+              <tr>
             <td>CBOR-LD Size</td><td><span v-text="cborLD.size"></span> bytes</td>
-          </tr>
-          <tr>
+              </tr>
+              <tr>
             <td>Compression</td><td><span v-text="cborLD.percentage"></span>%</td>
-          </tr>
-          <tr class="top aligned">
+              </tr>
+              <tr class="top aligned">
             <td>Hex</td><td v-text="cborLD.hex" style="word-wrap: break-word;"></td>
-          </tr>
-        </table>
+              </tr>
+            </table>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
   </div>
   <!-- errors -->
   <div class="ui error message" v-show="parseError.message">


### PR DESCRIPTION
This PR updates the JSON-LD Playground layout to display the output panel on the right-hand side of the JSON-LD input editor instead of below.


<img width="1906" height="859" alt="image" src="https://github.com/user-attachments/assets/61eec7a8-e414-46bd-b312-479c3d9ced58" />


[See demo](https://par-tec.github.io/json-ld.org/EricaCandido-7/playground/next/)
