### PR TITLE
Eleventy builds all subdirectories inside playground/ even when only playground/next is needed

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -36,7 +36,9 @@ export default async function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("functions/**/*.js");
   eleventyConfig.addPassthroughCopy("images/**/*.{htaccess,png,svg,xcf}");
   eleventyConfig.addPassthroughCopy("ns/**/*.{html,jsonld}");
-  eleventyConfig.addPassthroughCopy("playground/**/*.{css,php,js}");
+  // the playground is a special case, we want to copy the next version for development, but ignore the current version
+  eleventyConfig.addPassthroughCopy('playground/next');
+  eleventyConfig.addPassthroughCopy('playground/playground.css');
   eleventyConfig.addPassthroughCopy("presentations");
   eleventyConfig.addPassthroughCopy("schemas/**/*.json");
   eleventyConfig.addPassthroughCopy("site.css");
@@ -78,6 +80,11 @@ export default async function (eleventyConfig) {
     eleventyConfig.ignores.add(`spec/${draft}`);
   }
   eleventyConfig.ignores.add("test-suite");
+
+  // ignore the current playground version, we want to use the next version for development
+  eleventyConfig.ignores.add('playground/1.0');
+  eleventyConfig.ignores.add('playground/dev');
+  eleventyConfig.ignores.add('playground/index.html');
 
   eleventyConfig.addWatchTarget("playground/next/index.html");
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,33 +21,18 @@ export default async function (eleventyConfig) {
 
   eleventyConfig.addDataExtension("yaml", (contents) => YAML.parse(contents));
 
-  eleventyConfig.addPassthroughCopy(".htaccess");
   eleventyConfig.addPassthroughCopy("LICENSE.md");
-  eleventyConfig.addPassthroughCopy("_headers");
-  eleventyConfig.addPassthroughCopy("_redirects");
-  eleventyConfig.addPassthroughCopy("benchmarks/**/*.{jsonld,nq,md}");
-  eleventyConfig.addPassthroughCopy("contexts/**/*.{htaccess,html,jsonld}");
-  eleventyConfig.addPassthroughCopy(
-    "contexts/{event,person,place,recipe,remote-context}",
-  );
   eleventyConfig.addPassthroughCopy("examples/**/*.{html,ttl,txt,json,jsonld}");
   eleventyConfig.addPassthroughCopy("favicon.ico");
   eleventyConfig.addPassthroughCopy("fonts");
-  eleventyConfig.addPassthroughCopy("functions/**/*.js");
   eleventyConfig.addPassthroughCopy("images/**/*.{htaccess,png,svg,xcf}");
-  eleventyConfig.addPassthroughCopy("ns/**/*.{html,jsonld}");
-  // the playground is a special case, we want to copy the next version for development, but ignore the current version
-  eleventyConfig.addPassthroughCopy('playground/next');
-  eleventyConfig.addPassthroughCopy('playground/playground.css');
-  eleventyConfig.addPassthroughCopy("presentations");
-  eleventyConfig.addPassthroughCopy("schemas/**/*.json");
+  eleventyConfig.addPassthroughCopy({
+    "playground/next/editor.bundle.js": "editor.bundle.js",
+    "playground/next/editor.mjs": "editor.mjs",
+    "playground/playground.css": "playground.css",
+  });
   eleventyConfig.addPassthroughCopy("site.css");
-  eleventyConfig.addPassthroughCopy("spec/LICENSE.md");
-  for (const draft of drafts) {
-    eleventyConfig.addPassthroughCopy(`spec/${draft}`);
-  }
   eleventyConfig.addPassthroughCopy("static");
-  eleventyConfig.addPassthroughCopy("test-suite");
   eleventyConfig.addPassthroughCopy({
     "node_modules/fomantic-ui/dist/semantic.min.css":
       "static/css/fomantic-ui/semantic.min.css",
@@ -61,31 +46,28 @@ export default async function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
     "node_modules/bootstrap-italia": "static/bootstrap-italia",
   });
-  eleventyConfig.ignores.add("CONTRIBUTING.md");
-  eleventyConfig.ignores.add("LICENSE.md");
-  eleventyConfig.ignores.add("README.md");
-  eleventyConfig.ignores.add("benchmarks/README.md");
-  eleventyConfig.ignores.add("contexts/person.html");
-  eleventyConfig.ignores.add("examples");
-  eleventyConfig.ignores.add("images/Makefile");
-  eleventyConfig.ignores.add("images/README.md");
-  eleventyConfig.ignores.add("minutes/**/*");
-  eleventyConfig.ignores.add("ns/json-ld.html");
-  eleventyConfig.ignores.add("playground/dev/README.md");
-  eleventyConfig.ignores.add("presentations");
-  eleventyConfig.ignores.add("scripts");
-  eleventyConfig.ignores.add("spec/tools");
-  eleventyConfig.ignores.add("spec/LICENSE.md");
-  for (const draft of drafts) {
-    eleventyConfig.ignores.add(`spec/${draft}`);
-  }
-  eleventyConfig.ignores.add("test-suite");
 
-  // ignore the current playground version, we want to use the next version for development
-  eleventyConfig.ignores.add('playground/1.0');
-  eleventyConfig.ignores.add('playground/dev');
-  eleventyConfig.ignores.add('playground/index.html');
-
+  // ignore default files that are not needed for the build
+  eleventyConfig.ignores.add('CONTRIBUTING.md');
+  eleventyConfig.ignores.add('LICENSE.md');
+  eleventyConfig.ignores.add('README.md');
+  eleventyConfig.ignores.add('examples');
+  eleventyConfig.ignores.add('images/Makefile');
+  eleventyConfig.ignores.add('images/README.md');
+  eleventyConfig.ignores.add('presentations');
+  eleventyConfig.ignores.add('scripts');
+  eleventyConfig.ignores.add('test-suite');
+  eleventyConfig.ignores.add('benchmarks');
+  eleventyConfig.ignores.add('contexts');
+  eleventyConfig.ignores.add('CONTIBUTING');
+  eleventyConfig.ignores.add('learn');
+  eleventyConfig.ignores.add('LICENSE');
+  eleventyConfig.ignores.add('ns');
+  eleventyConfig.ignores.add('primer');
+  eleventyConfig.ignores.add('requirements');
+  eleventyConfig.ignores.add('schemas');
+  eleventyConfig.ignores.add('spec');
+  eleventyConfig.ignores.add('playground/**');
   eleventyConfig.addWatchTarget("playground/next/index.html");
 
   // setup development proxy to cloudflare pages function server

--- a/404.md
+++ b/404.md
@@ -1,5 +1,5 @@
 ---
-layout: fomantic
+layout: bootstrap_italia
 title: Page Not Found
 permalink: 404.html
 ---

--- a/_layouts/bootstrap_italia.liquid
+++ b/_layouts/bootstrap_italia.liquid
@@ -60,7 +60,7 @@
                     <span>Seguici su</span>
                     <ul>
                       <li>
-                        <a href="#" aria-label="Github" target="_blank">
+                        <a href="https://github.com/par-tec/json-ld.org" aria-label="Github" target="_blank">
                           <svg class="icon">
                             <use href="{{ site.baseUrl }}/static/bootstrap-italia/dist/svg/sprites.svg#it-github"></use>
                           </svg>
@@ -289,7 +289,7 @@
           </section>
         </div>
       </div>
-      <div class="it-footer-small-prints clearfix">
+      <!-- <div class="it-footer-small-prints clearfix">
         <div class="container">
           <h3 class="visually-hidden">Sezione Link Utili</h3>
           <ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row">
@@ -299,7 +299,7 @@
             <li class="list-inline-item"><a href="#" title="Mappa del sito">Mappa del sito</a></li>
           </ul>
         </div>
-      </div>
+      </div> -->
     </footer>
 
     <!-- Script tags -->

--- a/_layouts/bootstrap_italia.liquid
+++ b/_layouts/bootstrap_italia.liquid
@@ -39,7 +39,7 @@
     <link rel="shortcut icon" href="{{ site.baseUrl }}/favicon.ico">
   </head>
 
-  <body>
+  <body class="d-flex flex-column min-vh-100">
     <div class="it-nav-wrapper">
       <div class="it-header-center-wrapper">
         <div class="container">
@@ -74,11 +74,10 @@
           </div>
         </div>
       </div>
-      <div class="it-header-navbar-wrapper">
+      <!-- <div class="it-header-navbar-wrapper">
         <div class="container">
           <div class="row">
             <div class="col-12">
-              <!-- start nav -->
               <nav class="navbar navbar-expand-lg" aria-label="Navigazione principale">
                 <button
                   class="custom-navbar-toggler"
@@ -239,23 +238,25 @@
             </div>
           </div>
         </div>
-      </div>
+      </div> -->
     </div>
 
-    {% if masthead %}
+    <main class="flex-grow-1">
+      {% if masthead %}
+        <div class="container">
+          <div class="py-4">
+            <h1>{{ masthead.title }}</h1>
+            <p>{{ masthead.subtitle }}</p>
+          </div>
+        </div>
+      {% endif %}
+
       <div class="container">
         <div class="py-4">
-          <h1>{{ masthead.title }}</h1>
-          <p>{{ masthead.subtitle }}</p>
+          {{ content }}
         </div>
       </div>
-    {% endif %}
-
-    <div class="container">
-      <div class="py-4">
-        {{ content }}
-      </div>
-    </div>
+    </main>
 
     <footer class="it-footer">
       <div class="it-footer-main">

--- a/_layouts/bootstrap_italia.liquid
+++ b/_layouts/bootstrap_italia.liquid
@@ -108,7 +108,7 @@
                       <li class="nav-item">
                         <a
                           class="nav-link {% if page.url == '/playground/' %}active{% endif %}"
-                          href="{{ site.baseUrl }}/playground/"
+                          href="{{ site.baseUrl }}/playground/next"
                           {% if page.url == '/playground/' %}
                             aria-current="page"
                           {% endif %}

--- a/_layouts/fomantic.liquid
+++ b/_layouts/fomantic.liquid
@@ -50,7 +50,7 @@
         </a>
 
         <!-- Main menu items -->
-        <a class="item {% if page.url == '/playground/' %}active{% endif %}" href="{{ site.baseUrl }}/playground/">
+        <a class="item {% if page.url == '/playground/' %}active{% endif %}" href="{{ site.baseUrl }}/playground/next">
           <i class="beer icon"></i> Playground
         </a>
 

--- a/index.liquid
+++ b/index.liquid
@@ -24,7 +24,7 @@ title: Next Playground
     </li>
     <li>
       Other related playgrounds:
-      <a href="../1.0/">Classic JSON-LD 1.0 Playground</a> |
+      <!-- <a href="../1.0/">Classic JSON-LD 1.0 Playground</a> | -->
       <a href="https://vcplayground.org/">Verifiable Credentials Playground</a>
     </li>
   </ul>

--- a/index.liquid
+++ b/index.liquid
@@ -1,240 +1,701 @@
 ---
-layout: fomantic
-masthead:
-  title: JSON for Linking Data
-  subtitle: >-
-    Data is messy and disconnected. JSON-LD organizes and connects it,
-    creating a better Web.
+layout: bootstrap_italia
+title: Next Playground
 ---
 
+<h2 class="mb-4">JSON-LD Playground</h2>
 
-<div class="ui stackable grid">
-  <div class="justified four wide column">
-    <h2><i class="exchange alternate icon"></i> Linked Data</h2>
-    <p>
-      <a href="https://en.wikipedia.org/wiki/Linked_data">Linked Data</a>
-      empowers people that publish and use information on the Web. It is a
-      way to create a network of standards-based, machine-readable data across
-      Web sites. It allows an application to start at one piece of Linked Data,
-      and follow embedded links to other pieces of Linked Data that are hosted
-      on different sites across the Web.
-    </p>
-  </div>
-  <div class="eight wide column">
-    <div class="ui segment">
-      <a class="ui top right attached primary label"
-        href="/playground/#startTab=tab-expanded&json-ld=%7B%22%40context%22%3A%22https%3A%2F%2Fjson-ld.org%2Fcontexts%2Fperson.jsonld%22%2C%22%40id%22%3A%22http%3A%2F%2Fdbpedia.org%2Fresource%2FJohn_Lennon%22%2C%22name%22%3A%22John%20Lennon%22%2C%22born%22%3A%221940-10-09%22%2C%22spouse%22%3A%5B%22http%3A%2F%2Fdbpedia.org%2Fresource%2FYoko_Ono%22%2C%22http%3A%2F%2Fdbpedia.org%2Fresource%2FCynthia_Lennon%22%5D%7D"
-        >Open in Playground</a>
-      <pre style="margin: 0 !important;">{
-  "<span style="color: rgb(255, 122, 0);">@context</span>": "<a href="https://json-ld.org/contexts/person.jsonld">https://json-ld.org/contexts/person.jsonld</a>",
-  "<span style="color: rgb(255, 122, 0);">@id</span>": "<a href="http://dbpedia.org/resource/John_Lennon">http://dbpedia.org/resource/John_Lennon</a>",
-  "<span style="color: rgb(255, 122, 0);">name</span>": "<span style="color: rgb(0, 148, 0);">John Lennon</span>",
-  "<span style="color: rgb(255, 122, 0);">born</span>": "<span style="color: rgb(0, 0, 175);">1940-10-09</span>",
-  "<span style="color: rgb(255, 122, 0);">spouse</span>": [
-    "<a href="http://dbpedia.org/resource/Yoko_Ono">http://dbpedia.org/resource/Yoko_Ono</a>",
-    "<a href="http://dbpedia.org/resource/Cynthia_Lennon">http://dbpedia.org/resource/Cynthia_Lennon</a>"
-  ]
-}</pre></div>
-  </div>
-  <div class="justified four wide column">
-    <h2><img class="ui micro inline image" src="images/json-ld-data-32.png" alt="JSON-LD logo"> JSON-LD</h2>
-    <p>JSON-LD is a lightweight Linked Data format. It
-      is easy for humans to read and write. It is based on the already
-      successful JSON format and provides a way to help JSON data interoperate
-      at Web-scale. JSON-LD is an ideal data format for programming
-      environments, REST Web services, and unstructured databases such as
-      Apache CouchDB and MongoDB.
-    </p>
-  </div>
-</div>
-
-<div class="ui large center aligned segment" style="margin: 3em auto">
-  <div class="ui center aligned massive basic segment grid">
-    <div class="ui header">
-      <i class="beer icon"></i>
-      <span class="content">Playground</span>
-    </div>
-  </div>
-  <p class="ui basic huge left aligned padded segment">
-    The <strong>JSON-LD Playground</strong> is a web-based JSON-LD viewer and debugger.
-    If you are interested in learning JSON-LD, this tool will be of great help
-    to you. Developers may also use the tool to debug, visualize, and share
-    their JSON-LD markup.
-  </p>
-  <a href="./playground/" class="ui primary big button">Launch the JSON-LD Playground</a>
-</div>
-
-<div class="ui center aligned massive basic segment grid" id="developers">
-  <div class="ui header">
-    <i class="cog icon"></i>
-    <span class="content">Developers</span>
-  </div>
-</div>
-
-<p class="ui basic large center aligned segment">JSON-LD is available in
-  a number of popular programming environments. Each implementation of JSON-LD
-  listed below is fully conforming to the official JSON-LD specifications.
-</p>
-
-<div class="ui four stackable cards">
-  {% include 'implementation-card' language: 'JavaScript' %}
-  {% include 'implementation-card' language: 'Python' %}
-  {% include 'implementation-card' language: 'Ruby' %}
-  {% include 'implementation-card' language: 'Go' %}
-  {% include 'implementation-card' language: 'Java' %}
-  {% include 'implementation-card' language: 'C#' %}
-  {% include 'implementation-card' applicationCategory: 'CLI' %}
-  {% include 'implementation-card' language: 'Erlang,Elixir' %}
-  {% include 'implementation-card' language: 'PHP' %}
-  {% include 'implementation-card' language: 'Rust' %}
-  {% include 'implementation-card' language: 'TypeScript' %}
-</div>
-
-<div class="ui basic center aligned segment" id="tests-description">
+<div class="alert alert-primary" role="alert">
+  <strong>NOTES</strong>:
+  <ul>
+    <li>
+      The playground uses
+      <a href="https://github.com/digitalbazaar/jsonld.js">jsonld.js</a> which
+      <a href="https://github.com/digitalbazaar/jsonld.js#conformance"
+        >conforms</a
+      >
+      to JSON-LD 1.1
+      <a href="https://www.w3.org/TR/json-ld11/">syntax</a>
+      (<a href="https://w3c.github.io/json-ld-syntax/errata/">errata</a>),
+      <a href="https://www.w3.org/TR/json-ld11-api/">API</a>
+      (<a href="https://w3c.github.io/json-ld-api/errata/">errata</a>), and
+      <a href="https://www.w3.org/TR/json-ld11-framing/">framing</a>
+      (<a href="https://w3c.github.io/json-ld-framing/errata/">errata</a>).
+    </li>
+    <li>
+      Other related playgrounds:
+      <a href="../1.0/">Classic JSON-LD 1.0 Playground</a> |
+      <a href="https://vcplayground.org/">Verifiable Credentials Playground</a>
+    </li>
+  </ul>
   <p>
-    The <a href="https://w3c.github.io/json-ld-api/tests/">JSON-LD Test
-    Suite</a> (and <a
-    href="https://w3c.github.io/json-ld-framing/tests/">Framing Test Suite</a>)
-    is useful for validating JSON-LD Processors.
-  </p>
-  <p>
-    Conformance of various processors is documented in the official <a
-    href="https://w3c.github.io/json-ld-api/reports/">implementation report</a>.
+    Accesibility note: use <code>Esc</code> and then <code>Tab</code> (or
+    <code>Shift+Tab</code>) to navigate out of the editor.
   </p>
 </div>
 
-<div class="ui center aligned massive basic segment grid" id="collaborating">
-  <div class="ui header">
-    <i class="group icon"></i>
-    <span class="content">Getting Help / Collaborating</span>
+<div v-scope v-effect="setOutputTab()" @vue:mounted="gatherHash()">
+  <!-- errors -->
+  <div class="alert alert-danger" role="alert" v-show="parseError.message">
+    <p v-text="parseError.message"></p>
+    <pre
+      class="m-0"
+      v-text="JSON.stringify(parseError?.details?.event, null, 2)"
+    ></pre>
+  </div>
+
+  <!-- Examples buttons -->
+  <div class="d-flex flex-row justify-content-between align-items-center mb-3">
+    <div class="d-flex flex-wrap align-items-center gap-2">
+      <strong class="small text-body-secondary me-1">Examples:</strong>
+
+      <button
+        id="btn-person"
+        type="button"
+        class="btn btn-outline-primary btn-xs"
+        @click="loadExample('person.jsonld')"
+      >
+        Person
+      </button>
+      <button
+        id="btn-event"
+        type="button"
+        class="btn btn-outline-primary btn-xs"
+        @click="loadExample('event.jsonld')"
+      >
+        Event
+      </button>
+      <button
+        id="btn-place"
+        type="button"
+        class="btn btn-outline-primary btn-xs"
+        @click="loadExample('place.jsonld')"
+      >
+        Place
+      </button>
+      <button
+        id="btn-product"
+        type="button"
+        class="btn btn-outline-primary btn-xs"
+        @click="loadExample('product.jsonld')"
+      >
+        Product
+      </button>
+      <button
+        id="btn-recipe"
+        type="button"
+        class="btn btn-outline-primary btn-xs"
+        @click="loadExample('recipe.jsonld')"
+      >
+        Recipe
+      </button>
+      <button
+        id="btn-library"
+        type="button"
+        class="btn btn-outline-primary btn-xs"
+        @click="loadExample('library.jsonld')"
+      >
+        Library
+      </button>
+      <button
+        id="btn-activity"
+        type="button"
+        class="btn btn-outline-primary btn-xs"
+        @click="loadExample('activity.jsonld')"
+      >
+        Activity
+      </button>
+    </div>
+
+    <div class="d-flex flex-row justify-content-end align-items-center gap-2">
+      <!-- Copy link -->
+      <div class="dropdown dropstart text-center">
+        <a
+          class="btn btn-outline-primary btn-xs dropdown-toggle"
+          href="#"
+          role="button"
+          id="dropdownMenuShare"
+          data-bs-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
+          <svg class="icon icon-xs icon-primary">
+            <use
+              href="{{ site.baseUrl }}/static/bootstrap-italia/dist/svg/sprites.svg#it-link"
+            ></use>
+          </svg>
+        </a>
+        <div class="dropdown-menu p-0" aria-labelledby="dropdownMenuShare">
+          <div class="popover">
+            <h3 class="popover-header">
+              <svg class="icon">
+                <use
+                  href="{{ site.baseUrl }}/static/bootstrap-italia/dist/svg/sprites.svg#it-link"
+                ></use>
+              </svg>
+              Share this
+            </h3>
+            <div class="popover-body">
+              <div class="input-group">
+                <input
+                  id="permalinkURL"
+                  type="text"
+                  class="form-control"
+                  v-model="permalinkURL"
+                  @focus="$event.target.select()"
+                />
+                <div class="input-group-append">
+                  <button
+                    class="btn btn-primary"
+                    type="button"
+                    @click="copyPermalink()"
+                  >
+                    <svg
+                      role="img"
+                      class="icon icon-xs align-middle icon-white"
+                      aria-label="Copy link to clipboard"
+                    >
+                      <use
+                        href="{{ site.baseUrl }}/static/bootstrap-italia/dist/svg/sprites.svg#it-copy"
+                      ></use>
+                    </svg>
+                  </button>
+                </div>
+                <small
+                  id="permalinkURLHelp"
+                  class="form-text text-danger"
+                  v-show="permalinkURL.length > 2048"
+                >
+                  This link is longer than 2kb, and may not work.
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Keyboard shortcuts -->
+      <div class="dropdown dropstart text-center">
+        <a
+          class="btn btn-outline-primary btn-xs dropdown-toggle"
+          href="#"
+          role="button"
+          id="dropdownMenuKeyboardShortcuts"
+          data-bs-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
+          <svg class="icon icon-xs icon-primary">
+            <use
+              href="{{ site.baseUrl }}/static/bootstrap-italia/dist/svg/sprites.svg#it-help-circle"
+            ></use>
+          </svg>
+        </a>
+        <div class="dropdown-menu p-0" aria-labelledby="dropdownMenuShare">
+          <div class="popover">
+            <h3 class="popover-header">
+              <svg class="icon">
+                <use
+                  href="{{ site.baseUrl }}/static/bootstrap-italia/dist/svg/sprites.svg#it-help-circle"
+                ></use>
+              </svg>
+              Keyboard Shortcuts
+            </h3>
+            <div class="popover-body">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>Key</th>
+                    <th>Autocomplete</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <kbd>@</kbd>
+                    </td>
+                    <td>all of the <b>@</b> keywords</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <kbd>Ctrl+Space</kbd>
+                    </td>
+                    <td>available keys in <b>@context</b></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Navbar mode selector -->
+  <ul class="nav nav-pills mb-3">
+    <li class="nav-item" v-for="(tab, key) in tabs">
+      <a
+        href="#"
+        class="nav-link"
+        :class="{ active: outputTab == key, disabled: doc === '' }"
+        aria-current="page"
+        @click="setOutputTab(key)"
+      >
+        <i class="icon" :class="tab.icon"></i>
+        <span v-text="tab.label"></span>
+      </a>
+    </li>
+  </ul>
+
+  <!-- Messages -->
+  <div v-if="message.text" class="callout mb-3" :class="message.type">
+    <div class="callout-inner">
+      <div class="callout-title">
+        <svg class="icon">
+          <use
+            :href="{
+        '/bootstrap-italia/dist/svg/sprites.svg#it-help-circle' : message.type == 'info',
+        '/bootstrap-italia/dist/svg/sprites.svg#it-check-circle' : message.type == 'success',
+        '/bootstrap-italia/dist/svg/sprites.svg#it-times-circle' : message.type == 'error',
+        '/bootstrap-italia/dist/svg/sprites.svg#it-exclamation-triangle' : message.type == 'warning'
+        }"
+          ></use>
+        </svg>
+        <span
+          class="text"
+          v-text="{
+          'Info' : message.type == 'info',
+          'Message' : message.type == 'success',
+          'Error' : message.type == 'error',
+          'Warning' : message.type == 'warning'
+        }"
+        ></span>
+      </div>
+      <p v-text="message.text"></p>
+    </div>
+  </div>
+
+  <!-- main editor area -->
+  <div class="container px-0">
+    <div class="row">
+      <!-- Input fields -->
+      <div
+        :class="{ 
+          'col-12': editorColumns == '',
+          'col-6': editorColumns != ''
+        }"
+      >
+        <!-- Input 1 -->
+        <div class="pb-3">
+          <div class="ui top attached tabular menu">
+            <div
+              :class="{ active: inputTab == 'json-ld' }"
+              class="item"
+              @click="inputTab = 'json-ld'"
+              v-text="inputLabel"
+            >
+              <i class="pencil alternate icon"></i>
+            </div>
+            <div
+              :class="{ active: inputTab == 'options' }"
+              class="item"
+              @click="inputTab = 'options'"
+            >
+              <i class="wrench icon"></i> Options
+            </div>
+            <div class="right menu">
+              <div class="item pe-0">
+                <div class="ui icon input">
+                  <input
+                    type="text"
+                    placeholder="Document URL"
+                    v-model="remoteDocURL"
+                    @keyup.enter="retrieveDoc(mainEditor, 'doc', remoteDocURL)"
+                  />
+                  <i
+                    class="file link icon"
+                    :class="{ disabled: remoteDocURL == '' }"
+                    @click="retrieveDoc(mainEditor, 'doc', remoteDocURL)"
+                  ></i>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ui bottom attached fitted resizable scrolling segment mb-0"
+            v-show="inputTab == 'json-ld'"
+          >
+            <div id="editor" @vue:mounted="initMainEditor()">
+              <!-- replaced by CodeMirror -->
+            </div>
+          </div>
+          <div
+            class="ui bottom attached segment mb-0"
+            v-show="inputTab == 'options'"
+          >
+            <form class="ui form">
+              <div class="inline fields" id="options-api-processingMode">
+                <label for="options-api-processingMode" class="two wide field"
+                  >Processing Mode</label
+                >
+                <div class="field">
+                  <div class="ui radio checkbox">
+                    <input
+                      type="radio"
+                      id="options-api-processingMode-1-0"
+                      name="processingMode"
+                      value="json-ld-1.0"
+                      v-model="options.processingMode"
+                      @change="setOutputTab()"
+                    />
+                    <label for="options-api-processingMode-1-0"
+                      >JSON-LD 1.0</label
+                    >
+                  </div>
+                </div>
+                <div class="field">
+                  <div class="ui radio checkbox">
+                    <input
+                      type="radio"
+                      id="options-api-processingMode-1-1"
+                      name="processingMode"
+                      value="json-ld-1.1"
+                      v-model="options.processingMode"
+                      @change="setOutputTab()"
+                    />
+                    <label for="options-api-processingMode-1-1"
+                      >JSON-LD 1.1</label
+                    >
+                  </div>
+                </div>
+              </div>
+
+              <div class="inline fields" id="options-formatMode">
+                <label for="options-formatMode" class="two wide field"
+                  >Format</label
+                >
+                <div class="field">
+                  <div class="ui radio checkbox">
+                    <input
+                      type="radio"
+                      id="options-formatMode-json"
+                      name="formatMode"
+                      value="json"
+                      v-model="options.formatMode"
+                      @change="setOutputTab()"
+                    />
+                    <label for="options-formatMode-json">JSON</label>
+                  </div>
+                </div>
+                <div class="field">
+                  <div class="ui radio checkbox">
+                    <input
+                      type="radio"
+                      id="options-formatMode-yaml"
+                      name="formatMode"
+                      value="yaml"
+                      v-model="options.formatMode"
+                      @change="setOutputTab()"
+                    />
+                    <label for="options-formatMode-yaml">YAML</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="inline fields" id="options-api-base">
+                <label for="options-api-base" class="two wide field"
+                  >Base</label
+                >
+                <div class="sixteen wide field">
+                  <input
+                    type="text"
+                    id="options-api-base-url"
+                    placeholder="URL"
+                    v-model="options.base"
+                    @change="setOutputTab()"
+                  />
+                </div>
+              </div>
+
+              <div class="inline fields">
+                <label class="two wide field"></label>
+                <div class="field">
+                  <div class="ui checkbox">
+                    <input
+                      type="checkbox"
+                      id="options-api-compactArrays"
+                      v-model="options.compactArrays"
+                      @change="setOutputTab()"
+                    />
+                    <label for="options-api-compactArrays"
+                      >Compact Arrays</label
+                    >
+                  </div>
+                </div>
+              </div>
+
+              <div class="inline fields">
+                <label class="two wide field"></label>
+                <div class="field">
+                  <div class="ui checkbox">
+                    <input
+                      type="checkbox"
+                      id="options-api-compactToRelative"
+                      v-model="options.compactToRelative"
+                      @change="setOutputTab()"
+                    />
+                    <label for="options-api-compactToRelative"
+                      >Compact To Relative</label
+                    >
+                  </div>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="inline fields" id="options-api-rdfDirection">
+                  <label for="options-api-rdfDirection" class="two wide field"
+                    >RDF Direction Mode</label
+                  >
+                  <div class="field">
+                    <div class="ui radio checkbox">
+                      <input
+                        type="radio"
+                        id="options-api-rdfDirection-default"
+                        name="rdfDirection"
+                        value=""
+                        checked
+                        v-model="options.rdfDirection"
+                        @change="setOutputTab()"
+                      />
+                      <label for="options-api-rdfDirection-default"
+                        >Default (null)</label
+                      >
+                    </div>
+                  </div>
+                  <div class="field">
+                    <div class="ui radio checkbox">
+                      <input
+                        type="radio"
+                        id="options-api-rdfDirection-i18n-datatype"
+                        name="rdfDirection"
+                        value="i18n-datatype"
+                        v-model="options.rdfDirection"
+                        @change="setOutputTab()"
+                      />
+                      <label for="options-api-rdfDirection-i18n-datatype"
+                        >"i18n-datatype"</label
+                      >
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="inline fields" id="options-api-safe">
+                  <label for="options-api-safe" class="two wide field"
+                    >Safe</label
+                  >
+                  <div class="field">
+                    <div class="ui radio checkbox">
+                      <input
+                        type="radio"
+                        id="options-api-safe-false"
+                        name="safe"
+                        :value="false"
+                        v-model="options.safe"
+                        @change="setOutputTab()"
+                      />
+                      <label for="options-api-safe-false">False</label>
+                    </div>
+                  </div>
+                  <div class="field">
+                    <div class="ui radio checkbox">
+                      <input
+                        type="radio"
+                        id="options-api-safe-true"
+                        name="safe"
+                        :value="true"
+                        v-model="options.safe"
+                        @change="setOutputTab()"
+                      />
+                      <label for="options-api-safe-true">True</label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <!-- Input 2 -->
+        <div class="pb-3" v-show="editorColumns != ''">
+          <div class="ui top attached tabular menu">
+            <div
+              class="icon item"
+              v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+            >
+              <i
+                class="arrow alternate circle down outline icon cursor-pointer"
+                title='Copy `@context` from "JSON-LD Input"'
+                @click="copyContext()"
+              ></i>
+            </div>
+            <div class="active item">
+              <i class="pencil alternate icon"></i>
+              <span
+                v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+                v-text="contextInputLabel"
+              ></span>
+              <span
+                v-show="outputTab == 'framed'"
+                v-text="frameInputLabel"
+              ></span>
+            </div>
+            <div class="right menu">
+              <div class="item pe-0">
+                <div class="ui icon input">
+                  <input
+                    type="text"
+                    :placeholder="sideEditorURLFieldPlaceholderText"
+                    v-model="remoteSideDocURL"
+                    @keyup.enter="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"
+                  />
+                  <i
+                    class="file link icon"
+                    @click="retrieveDoc(sideEditor, sideDoc, remoteSideDocURL)"
+                  ></i>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="ui bottom attached fitted resizable scrolling segment mb-0"
+          >
+            <div
+              id="context-editor"
+              v-show="outputTab == 'compacted' || outputTab == 'flattened'"
+              @vue:mounted="initContextEditor()"
+            >
+              <!-- replaced by CodeMirror -->
+            </div>
+            <div
+              id="frame-editor"
+              v-show="outputTab == 'framed'"
+              @vue:mounted="initFrameEditor()"
+            >
+              <!-- replaced by CodeMirror -->
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Output fields -->
+      <div
+        :class="{
+          'col-12': editorColumns == '',
+          'col-6': editorColumns != ''
+        }"
+      >
+        <div class="pb-3 d-flex flex-column h-100">
+          <div class="ui top attached tabular menu">
+            <div class="active item">
+              <span>Output:</span>
+            </div>
+          </div>
+
+          <div
+            class="ui bottom attached fitted segment mb-0 d-flex flex-column h-100"
+          >
+            <div
+              v-show="outputTab != 'table'"
+              class="ui fitted resizable scrolling segment basic mb-0 flex-grow-1"
+            >
+              <div id="read-only-editor">
+                <!-- replaced by CodeMirror -->
+              </div>
+            </div>
+
+            <div
+              v-if="outputTab == 'table'"
+              class="ui bottom attached fitted resizable scrolling segment mb-0 flex-grow-1"
+            >
+              <table
+                class="ui compact table mt-0"
+                v-show="outputTab == 'table'"
+              >
+                <thead>
+                  <tr>
+                    <th>Subject</th>
+                    <th>Predicate</th>
+                    <th>Object</th>
+                    <th>Language</th>
+                    <th>Datatype</th>
+                    <th>Graph</th>
+                  </tr>
+                </thead>
+                <tr v-for="quad in tableQuads">
+                  <td>
+                    <a
+                      v-if="quad.subject.termType == 'NamedNode'"
+                      :href="quad.subject.value"
+                      v-text="quad.subject.value"
+                    ></a>
+                    <span v-else v-text="quad.subject.value"></span>
+                  </td>
+                  <td>
+                    <a
+                      v-if="quad.predicate.termType == 'NamedNode'"
+                      :href="quad.predicate.value"
+                      v-text="quad.predicate.value"
+                    ></a>
+                    <span v-else v-text="quad.predicate.value"></span>
+                  </td>
+                  <td>
+                    <a
+                      v-if="quad.object.termType == 'NamedNode'"
+                      :href="quad.object.value"
+                      v-text="quad.object.value"
+                    ></a>
+                    <span v-else v-text="quad.object.value"></span>
+                  </td>
+                  <td v-text="quad.object.language"></td>
+                  <td>
+                    <a
+                      v-if="quad.object.datatype"
+                      :href="quad.object.datatype.value"
+                      v-text="quad.object.datatype.value"
+                    ></a>
+                  </td>
+                  <td v-text="quad.graph.value"></td>
+                </tr>
+              </table>
+            </div>
+
+            <div v-if="outputTab == 'cborld'">
+              <table class="ui fixed definition table">
+                <tr>
+                  <td class="three wide">JSON-LD Size</td>
+                  <td><span v-text="cborLD.jsonldSize"></span> bytes</td>
+                </tr>
+                <tr>
+                  <td>CBOR-LD Size</td>
+                  <td><span v-text="cborLD.size"></span> bytes</td>
+                </tr>
+                <tr>
+                  <td>Compression</td>
+                  <td><span v-text="cborLD.percentage"></span>%</td>
+                </tr>
+                <tr class="top aligned">
+                  <td>Hex</td>
+                  <td v-text="cborLD.hex" class="text-break"></td>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
-<div class="ui large basic padded segment">
-  <div class="ui two column grid">
-    <div class="column">
-      <h4 class="ui small header">JSON-LD Community Group</h4>
-      <div class="ui compact text menu" style="margin-bottom: .5em">
-        <div class="item">
-          <i class="mail icon"></i>
-          <a href="https://lists.w3.org/Archives/Public/public-json-ld/">Mailing List</a>
-        </div>
-        <div class="item">
-          <i class="calendar icon"></i>
-          <a href="https://www.w3.org/groups/cg/json-ld/calendar/">Call Schedule</a>
-        </div>
-        <div class="item">
-          <i class="github icon"></i>
-          <a href="https://github.com/json-ld/">GitHub Organization</a>
-        </div>
-      </div>
-      <p>
-The <a
-href="https://www.w3.org/groups/cg/json-ld/">JSON-LD Community Group</a> is an
-excellent place to collaborate on JSON-LD technologies. Anyone may join the
-group and participate on the mailing list, join discussion calls, and collaborate
-on Community Group projects.
-      </p>
-    </div>
-    <div class="column">
-      <h4 class="ui small header">JSON-LD Working Group</h4>
-      <div class="ui compact text menu" style="margin-bottom: .5em">
-        <div class="item">
-          <i class="mail icon"></i>
-          <a href="https://lists.w3.org/Archives/Public/public-json-ld-wg/">Mailing List</a>
-        </div>
-        <div class="item">
-          <i class="calendar icon"></i>
-          <a href="https://www.w3.org/groups/wg/json-ld/calendar/">Call Schedule</a>
-        </div>
-        <div class="item">
-          <i class="github icon"></i>
-          <a href="https://github.com/search?q=topic%3Ajson-ld-wg+org%3Aw3c&type=Repositories">Specification Repositories</a>
-        </div>
-      </div>
-      <p>
-The W3C <a href="https://www.w3.org/groups/wg/json-ld/">JSON-LD Working
-Group</a> is responsible for the formal specification of JSON-LD. The <a
-href="https://www.w3.org/groups/wg/json-ld/charters/active/">most recent
-charter</a> runs through <time datetime="2028-01-31">January 2028</time>. To
-participate in this work, please <a
-href="https://www.w3.org/Consortium/join">join the W3C</a> and then <a
-href="https://www.w3.org/groups/wg/json-ld/instructions/">join the Working
-Group</a>. Prior to joining, the <a
-href="https://lists.w3.org/Archives/Public/public-json-ld-wg/">Working Group
-mailing list</a> is visible to the public and participation in the <a
-href="https://github.com/search?q=topic%3Ajson-ld-wg+org%3Aw3c&type=Repositories">specification
-repositories</a> is encouraged.
-      </p>
-    </div>
-  </div>
-</div>
-
-<div class="ui four stackable cards">
-  <div class="card">
-    <div class="content">
-      <div class="header"><h3>Code</h3></div>
-      <div class="description">
-        <ul>
-          <li><a href="https://github.com/json-ld/json-ld.org"><code>json-ld</code> GitHub Organization</a></li>
-          <li><a href="https://github.com/search?q=topic%3Ajson-ld-wg+org%3Aw3c&type=Repositories">Specification Repositories</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div class="card">
-    <div class="content">
-      <div class="header"><h3>Meetings and Minutes</h3></div>
-      <div class="description">
-        <ul>
-          <li><a href="https://www.w3.org/groups/cg/json-ld/calendar/">Community Group Calls</a></li>
-          <li><a href="https://www.w3.org/groups/wg/json-ld/calendar/">Working Group Calls</a></li>
-          <li><a href="minutes/">Text and audio minutes</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div class="card">
-    <div class="content">
-      <div class="header"><h3>Mailing Lists</h3></div>
-      <div class="description">
-        <ul>
-          <li><a href="https://lists.w3.org/Archives/Public/public-json-ld/">Community Group Mailing List</a></li>
-          <li><a href="https://lists.w3.org/Archives/Public/public-json-ld-wg/">Working Group Mailing List</a></li>
-          <li><a href="http://lists.w3.org/Archives/Public/public-linked-json/">General <abbr title="Question and Answer">Q&A</abbr> List</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-  <div class="card">
-    <div class="content">
-      <div class="header">Discussion</div>
-      <div class="description">
-        <ul>
-          <li><a href="https://irc.w3.org/?channels=#json-ld">#json-ld on irc.w3.org</a></li>
-          <li><a href="https://github.com/orgs/json-ld/discussions">Discussions on GitHub</a></li>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="ui divider"></div>
-
-<div class="ui center aligned massive basic segment grid" id="learn-more">
-  <div class="ui header">
-    <i class="book icon"></i>
-    <span class="content">Learn More...</span>
-  </div>
-</div>
-
-<div class="ui large basic center aligned segment">
-  <p>
-  This website contains a number of curated video, presentations, tutorials, and
-  documentation about JSON-LD. Assuming you are familiar with JSON, these
-  training materials will help you quickly put the power of JSON-LD into your
-  web development efforts.
-  </p>
-  <p>
-    <a class="ui primary button" href="./learn/">Learn more about JSON-LD</a>
-  </p>
-</div>
+<script src="./editor.bundle.js"></script>

--- a/playground/next/editor.mjs
+++ b/playground/next/editor.mjs
@@ -434,12 +434,12 @@ window.app = createApp({
     }
   },
   async loadExample(file) {
-    const rv = await fetch(`../../examples/playground/${file}`);
+    const rv = await fetch(`./examples/playground/${file}`);
     this.doc = await rv.json();
     setEditorValue(this.mainEditor, this.doc);
     // TODO: make this less of a hack...so we can provide other frames
     if (file === 'library.jsonld') {
-      const frame = await fetch(`../../examples/playground/library-frame.jsonld`);
+      const frame = await fetch(`./examples/playground/library-frame.jsonld`);
       this.frameDoc = await frame.json();
       setEditorValue(this.frameEditor, this.frameDoc);
     } else {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,7 +3,7 @@ import {nodeResolve} from "@rollup/plugin-node-resolve"
 export default {
   input: "./playground/next/editor.mjs",
   output: {
-    file: "./_site/playground/next/editor.bundle.js",
+    file: "./_site/editor.bundle.js",
     format: "iife"
   },
   plugins: [

--- a/tests/playground/next/playground-next.spec.js
+++ b/tests/playground/next/playground-next.spec.js
@@ -1,15 +1,15 @@
 import { test, expect } from "@playwright/test";
 
 test("playground next opens successfully", async ({ page }) => {
-  await page.goto("/playground/next/");
-  await expect(page).toHaveURL(/\/playground\/next\/?/);
+  await page.goto("/");
+  await expect(page).toHaveURL("/");
   await expect(
     page.getByRole("heading", { name: "JSON-LD Playground" }),
   ).toBeVisible();
 });
 
 test("format radio switches output between JSON and YAML", async ({ page }) => {
-  await page.goto("/playground/next/");
+  await page.goto("/");
   await page.getByRole("button", { name: "Person" }).click();
   await expect(page.locator("#read-only-editor .cm-content")).toBeVisible();
 
@@ -49,7 +49,7 @@ test("permalink button opens popup and copy copies URL to clipboard", async ({
   context,
 }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-  await page.goto("/playground/next/");
+  await page.goto("/");
   await page.getByRole("button", { name: "Person" }).click();
   await expect(page.locator("#read-only-editor .cm-content")).toBeVisible();
 
@@ -87,7 +87,7 @@ test("URL hash params auto-populate json-ld, frame, startTab, formatMode and pro
     startTab: "tab-framed",
     formatMode: "yaml",
   });
-  await page.goto(`/playground/next/#${hash.toString()}`);
+  await page.goto(`/#${hash.toString()}`);
   await page.waitForLoadState("networkidle");
 
   const mainEditor = page.locator("#editor .cm-content");

--- a/tests/playground/next/playground-next.spec.js
+++ b/tests/playground/next/playground-next.spec.js
@@ -115,3 +115,116 @@ test("URL hash params auto-populate json-ld, frame, startTab, formatMode and pro
   expect(outputText).toBeTruthy();
   expect(outputText).toContain("Alice");
 });
+
+test("click Person loads the resource successfully", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse(res =>
+    res.url().includes("/examples/playground/person.json") &&
+    res.status() === 200
+  );
+
+  await page.getByRole("button", { name: "Person" }).click();
+
+  const response = await responsePromise;
+
+  const json = await response.json();
+  expect(json).toHaveProperty("@context");
+});
+
+test("click Event loads the resource successfully", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse(res =>
+    res.url().includes("/examples/playground/event.json") &&
+    res.status() === 200
+  );
+
+  await page.getByRole("button", { name: "Event" }).click();
+
+  const response = await responsePromise;
+
+  const json = await response.json();
+  expect(json).toHaveProperty("@context");
+});
+
+test("click Place loads the resource successfully", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse(res =>
+    res.url().includes("/examples/playground/place.json") &&
+    res.status() === 200
+  );
+
+  await page.getByRole("button", { name: "Place" }).click();
+
+  const response = await responsePromise;
+
+  const json = await response.json();
+  expect(json).toHaveProperty("@context");
+});
+
+test("click Product loads the resource successfully", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse(res =>
+    res.url().includes("/examples/playground/product.json") &&
+    res.status() === 200
+  );
+
+  await page.getByRole("button", { name: "Product" }).click();
+
+  const response = await responsePromise;
+
+  const json = await response.json();
+  expect(json).toHaveProperty("@context");
+});
+
+
+test("click Recipe loads the resource successfully", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse(res =>
+    res.url().includes("/examples/playground/recipe.json") &&
+    res.status() === 200
+  );
+
+  await page.getByRole("button", { name: "Recipe" }).click();
+
+  const response = await responsePromise;
+
+  const json = await response.json();
+  expect(json).toHaveProperty("@context");
+});
+
+test("click Library loads the resource successfully", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse(res =>
+    res.url().includes("/examples/playground/library.json") &&
+    res.status() === 200
+  );
+
+  await page.getByRole("button", { name: "Library" }).click();
+
+  const response = await responsePromise;
+
+  const json = await response.json();
+  expect(json).toHaveProperty("@context");
+});
+
+test("click Activity loads the resource successfully", async ({ page }) => {
+  await page.goto("/");
+
+  const responsePromise = page.waitForResponse(res =>
+    res.url().includes("/examples/playground/activity.json") &&
+    res.status() === 200
+  );
+
+  await page.getByRole("button", { name: "Activity" }).click();
+
+  const response = await responsePromise;
+
+  const json = await response.json();
+  expect(json).toHaveProperty("@context");
+});


### PR DESCRIPTION
## This PR

- [ Exclude legacy folders (playground/1.0, playground/dev, etc.) ]
- [ Exclude the root playground/index.html ]
- [ Inclde the entire playground/next directory ]
- [ Include specific shared files such as playground/playground.css ]
- [ Update the link on the index page so that it points to playground/next ]
- [ Do not change the visible URL itself; only update the target path to playground/next ]

## It's done

- Using targeted passthroughCopy rules to include only playground/next and the required shared assets.
- Adding precise ignore rules to prevent Eleventy from processing or outputting outdated HTML files and folders.
- Adjusting the index page link so users are correctly routed to the new playground without altering the visible URL structure.
- This approach keeps the build clean, reduces unnecessary output, and ensures that only the intended playground version is exposed.

## Checks

- [ Link: https://par-tec.github.io/json-ld.org/lleonori-23-eleventy-builds-all-subdirectories-inside-playground-even-when-only-playgroundnext-is-needed/playground/next/]